### PR TITLE
fix(mcp): remove duplicate tool definitions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,11 @@
 {
 	"mcpServers": {
+		"pykis-local": {
+			"type": "stdio",
+			"command": "/home/unohee/RTX_ENV/bin/python",
+			"args": ["-m", "pykis_mcp_server"],
+			"cwd": "/home/unohee/dev/tools/pykis"
+		},
 		"task-master-ai": {
 			"type": "stdio",
 			"command": "npx",

--- a/pykis-mcp-server/src/pykis_mcp_server/tools/order_tools.py
+++ b/pykis-mcp-server/src/pykis_mcp_server/tools/order_tools.py
@@ -69,47 +69,6 @@ async def order_stock_credit(
 
 
 @server.tool()
-async def inquire_order_psbl(pdno: str, ord_unpr: str) -> Dict[str, Any]:
-    """현금 주문 가능 조회
-
-    Args:
-        pdno: 종목코드 6자리
-        ord_unpr: 주문 단가
-
-    Returns:
-        Dict: 주문 가능 수량 정보
-    """
-    if not pdno or len(pdno) != 6:
-        raise InvalidParameterError("pdno", "종목코드는 6자리여야 합니다")
-
-    agent = get_agent()
-    result = agent.inquire_order_psbl(pdno, ord_unpr)
-    return validate_api_response(result, "현금 주문 가능 조회")
-
-
-@server.tool()
-async def inquire_credit_order_psbl(
-    pdno: str, ord_unpr: str, crdt_type: str = "21"
-) -> Dict[str, Any]:
-    """신용 주문 가능 조회
-
-    Args:
-        pdno: 종목코드 6자리
-        ord_unpr: 주문 단가
-        crdt_type: 신용 유형 ("21":자기융자, "22":유통융자)
-
-    Returns:
-        Dict: 신용 주문 가능 수량 정보
-    """
-    if not pdno or len(pdno) != 6:
-        raise InvalidParameterError("pdno", "종목코드는 6자리여야 합니다")
-
-    agent = get_agent()
-    result = agent.inquire_credit_order_psbl(pdno, ord_unpr, crdt_type)
-    return validate_api_response(result, "신용 주문 가능 조회")
-
-
-@server.tool()
 async def order_cash(code: str, qty: str, price: str, order_type: str) -> Dict[str, Any]:
     """현금 매수
 
@@ -271,15 +230,3 @@ async def order_resv_ccnl() -> Dict[str, Any]:
     agent = get_agent()
     result = agent.order_resv_ccnl()
     return validate_api_response(result, "예약 주문 전체 취소")
-
-
-@server.tool()
-async def inquire_psbl_rvsecncl() -> Dict[str, Any]:
-    """정정/취소 가능 주문 조회
-
-    Returns:
-        Dict: 정정/취소 가능한 주문 리스트
-    """
-    agent = get_agent()
-    result = agent.inquire_psbl_rvsecncl()
-    return validate_api_response(result, "정정/취소 가능 주문 조회")

--- a/pykis-mcp-server/src/pykis_mcp_server/tools/utility_tools.py
+++ b/pykis-mcp-server/src/pykis_mcp_server/tools/utility_tools.py
@@ -171,18 +171,6 @@ async def inquire_vi_status(stock_code: str = "") -> Dict[str, Any]:
 
 
 @server.tool()
-async def get_rate_limiter_status() -> Dict[str, Any]:
-    """Rate Limiter 상태 조회
-
-    Returns:
-        Dict: Rate Limiter 현재 상태 정보
-    """
-    agent = get_agent()
-    result = agent.get_rate_limiter_status()
-    return {"success": True, "data": result}
-
-
-@server.tool()
 async def get_condition_stocks(
     user_id: str, seq: int, div_code: str = "N"
 ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Remove 4 duplicate MCP tool definitions causing FastMCP warnings
- Add pykis-local MCP server configuration for Claude Code integration

## Changes
### Duplicate Tools Removed
| Tool | Removed From | Kept In |
|------|-------------|---------|
| `inquire_order_psbl` | order_tools.py | account_tools.py |
| `inquire_credit_order_psbl` | order_tools.py | account_tools.py |
| `inquire_psbl_rvsecncl` | order_tools.py | account_tools.py |
| `get_rate_limiter_status` | utility_tools.py | rate_limiter_tools.py |

### MCP Configuration
- Added `pykis-local` server to `.mcp.json` for local development testing

## Test Plan
- [x] Verify MCP server starts without duplicate warnings
- [x] Verify all 4 tools remain accessible from canonical locations
- [x] Run MCP server tests (59/61 passing)
- [x] Test MCP tools via Claude Code integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)