### PR TITLE
feat(cli,mcp): add stock name display and search by name/code

### DIFF
--- a/kis_agent/cli/main.py
+++ b/kis_agent/cli/main.py
@@ -31,6 +31,7 @@ from kis_agent.cli.field_map import (
     OVERSEAS_OPTION_PRICE,
     OVERSEAS_PRICE,
     OVERSEAS_PRICE_DETAIL,
+    PENDING_ORDER,
     PERIOD_PROFIT,
     STOCK_PRICE,
     TRADE_EXECUTION,
@@ -38,6 +39,8 @@ from kis_agent.cli.field_map import (
     remap,
 )
 from kis_agent.cli.schema import get_schema
+from kis_agent.utils.stock_master import resolve_code
+from kis_agent.utils.stock_master import search as search_stocks
 
 
 def _create_agent():
@@ -147,13 +150,48 @@ def _out(data, pretty=False):
     print(json.dumps(data, ensure_ascii=False, indent=indent, default=str))
 
 
+def _resolve(code_or_name: str) -> str:
+    """종목코드 또는 종목명을 종목코드(6자리)로 변환. 실패 시 원본 반환."""
+    resolved = resolve_code(code_or_name)
+    if resolved:
+        return resolved
+    return code_or_name
+
+
 def _get_name(agent, code: str):
-    """종목명 조회."""
+    """국내 종목명 조회."""
     try:
         data = agent.stock_api.search_stock_info(code=code)
         if data and data.get("output"):
             o = data["output"]
             return o.get("prdt_abrv_name") or o.get("prdt_name")
+    except Exception:
+        pass
+    return None
+
+
+# 해외 거래소코드 → 상품유형코드 매핑 (get_stock_info용)
+_OVERSEAS_EXCD_TO_PRDT_TYPE = {
+    "NAS": "512", "NYS": "512", "AMS": "512",  # 미국
+    "HKS": "513",  # 홍콩
+    "SHS": "514",  # 중국 상해A
+    "SZS": "515",  # 중국 심천A
+    "TSE": "516",  # 일본
+    "HNX": "517", "HSX": "517",  # 베트남
+}
+
+
+def _get_overseas_name(agent, excd: str, symb: str):
+    """해외 종목명 조회."""
+    try:
+        prdt_type_cd = _OVERSEAS_EXCD_TO_PRDT_TYPE.get(excd, "512")
+        pdno = f"{excd}.{symb}"
+        data = agent.overseas_api.get_stock_info(
+            prdt_type_cd=prdt_type_cd, pdno=pdno
+        )
+        if data and data.get("output"):
+            o = data["output"]
+            return o.get("prdt_name") or o.get("prdt_eng_name")
     except Exception:
         pass
     return None
@@ -167,7 +205,7 @@ def _get_name(agent, code: str):
 def cmd_price(args):
     """국내 주식 현재가 조회. --daily로 일별 시세 포함."""
     agent = _create_agent()
-    code = args.code
+    code = _resolve(args.code)
 
     result = {"stock": {"code": code}}
 
@@ -218,7 +256,7 @@ def cmd_balance(args):
 def cmd_orderbook(args):
     """호가(매수/매도 10호가) 조회."""
     agent = _create_agent()
-    code = args.code
+    code = _resolve(args.code)
 
     result = {"stock": {"code": code}}
     name = _get_name(agent, code)
@@ -254,6 +292,11 @@ def cmd_overseas(args):
 
     result = {"overseas": {"exchange": excd, "symbol": symb}}
 
+    # 종목명
+    name = _get_overseas_name(agent, excd, symb)
+    if name:
+        result["overseas"]["name"] = name
+
     if args.detail:
         data = agent.overseas_api.get_price_detail(excd=excd, symb=symb)
         if data and data.get("output"):
@@ -275,9 +318,13 @@ def cmd_overseas(args):
 
 
 def cmd_futures(args):
-    """선물옵션 시세 조회. --overseas로 해외선물, --option으로 해외옵션."""
+    """선물옵션 시세 조회. --overseas로 해외선물, --option으로 해외옵션, --night로 야간."""
     agent = _create_agent()
     code = args.code
+
+    # 야간 선물옵션 모드
+    if args.night:
+        return _cmd_futures_night(agent, args, code)
 
     if args.overseas or args.option:
         # 해외선물/옵션
@@ -319,6 +366,46 @@ def cmd_futures(args):
             if name:
                 result["futures"]["name"] = name
             result["futures"]["price"] = mapped
+
+    _out({"data": result}, args.pretty)
+
+
+def _cmd_futures_night(agent, args, code):
+    """야간 선물옵션 조회."""
+    result = {"nightFutures": {"code": code}}
+
+    # --balance: 야간 잔고
+    if args.balance:
+        data = agent.futures_api.inquire_ngt_balance()
+        if data and data.get("output"):
+            items = data["output"] if isinstance(data["output"], list) else [data["output"]]
+            result["nightFutures"]["balance"] = items
+        else:
+            result["nightFutures"]["balance"] = []
+        _out({"data": result}, args.pretty)
+        return
+
+    # --ccnl: 야간 체결내역
+    if args.ccnl:
+        data = agent.futures_api.inquire_ngt_ccnl()
+        if data and data.get("output"):
+            items = data["output"] if isinstance(data["output"], list) else [data["output"]]
+            result["nightFutures"]["executions"] = items
+        else:
+            result["nightFutures"]["executions"] = []
+        _out({"data": result}, args.pretty)
+        return
+
+    # 기본: 야간선물 시세 (기존 inquire-price에 야간 종목코드 사용)
+    data = agent.futures_api.get_price(code=code)
+    if data and data.get("output"):
+        mapped = remap(data["output"], FUTURES_PRICE)
+        name = mapped.pop("name", None)
+        if name:
+            result["nightFutures"]["name"] = name
+        result["nightFutures"]["price"] = mapped
+    elif data and data.get("rt_cd") != "0":
+        result["nightFutures"]["error"] = data.get("msg1", "조회 실패")
 
     _out({"data": result}, args.pretty)
 
@@ -558,6 +645,386 @@ def _cmd_trades_profit(agent, args, start, end, stock_filter):
     _out({"data": result}, args.pretty)
 
 
+# ============================================================
+# 주문 타입 매핑
+# ============================================================
+
+# 국내주식 주문구분 코드
+_DOMESTIC_ORDER_TYPES = {
+    "limit": "00",       # 지정가
+    "market": "01",      # 시장가
+    "cond": "02",        # 조건부지정가
+    "best": "03",        # 최유리지정가
+    "pre": "05",         # 장전시간외
+    "after": "06",       # 장후시간외
+    "ioc": "11",         # IOC지정가
+    "fok": "12",         # FOK지정가
+}
+
+# 해외주식 주문구분 코드
+_OVERSEAS_ORDER_TYPES = {
+    "limit": "00",       # 지정가
+    "moo": "31",         # MOO (매도만)
+    "loo": "32",         # LOO
+    "moc": "33",         # MOC (매도만)
+    "loc": "34",         # LOC
+}
+
+# 해외주식 거래소 매핑 (조회용 → 주문용)
+_OVERSEAS_EXCG_MAP = {
+    "NAS": "NASD", "NYS": "NYSE", "AMS": "AMEX",
+    "HKS": "SEHK", "SHS": "SHAA", "SZS": "SZAA",
+    "TSE": "TKSE", "HNX": "HASE", "HSX": "VNSE",
+    # 주문용 코드 직접 입력도 허용
+    "NASD": "NASD", "NYSE": "NYSE", "AMEX": "AMEX",
+    "SEHK": "SEHK", "SHAA": "SHAA", "SZAA": "SZAA",
+    "TKSE": "TKSE", "HASE": "HASE", "VNSE": "VNSE",
+}
+
+
+def _confirm_order(action: str, details: dict) -> bool:
+    """주문 실행 전 확인. --yes 없으면 stderr로 확인 프롬프트."""
+    import sys
+
+    info_lines = [f"  {k}: {v}" for k, v in details.items() if v]
+    msg = f"\n{'='*50}\n  [{action}]\n{'='*50}\n"
+    msg += "\n".join(info_lines)
+    msg += f"\n{'='*50}\n"
+    sys.stderr.write(msg)
+    sys.stderr.write("  실행하시겠습니까? (y/N): ")
+    sys.stderr.flush()
+    try:
+        answer = input().strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
+
+
+def cmd_order(args):
+    """주문 실행 — 매수/매도/취소/정정/미체결 조회."""
+    action = args.action
+
+    if action == "list":
+        return _cmd_order_list(args)
+    elif action in ("buy", "sell"):
+        return _cmd_order_execute(args)
+    elif action == "cancel":
+        return _cmd_order_cancel(args)
+    elif action == "modify":
+        return _cmd_order_modify(args)
+    else:
+        _out({"error": f"Unknown action: {action}. Use: buy, sell, cancel, modify, list"})
+        sys.exit(1)
+
+
+def _cmd_order_list(args):
+    """미체결 주문 목록 조회."""
+    agent = _create_agent()
+
+    if args.overseas:
+        # 해외주식 미체결
+        excd = _OVERSEAS_EXCG_MAP.get(args.overseas.upper(), args.overseas.upper())
+        data = agent.overseas_api.get_nccs_orders(ovrs_excg_cd=excd)
+    else:
+        # 국내주식 미체결
+        data = agent.account_api.inquire_psbl_rvsecncl()
+
+    if not data:
+        _out({"error": "미체결 주문 조회 실패"})
+        return
+
+    items = data.get("output", data.get("output1", []))
+    if not items:
+        _out({"data": {"orders": {"count": 0, "items": []}}}, args.pretty)
+        return
+
+    mapped = []
+    for item in items:
+        m = remap(item, PENDING_ORDER)
+        if m.get("date"):
+            m["date"] = _fmt_date(m["date"])
+        if m.get("time"):
+            m["time"] = _fmt_time(m["time"])
+        for k in ["orderQty", "orderPrice", "filledQty", "remainQty"]:
+            if k in m:
+                m[k] = _fmt_number(m[k])
+        mapped.append(m)
+
+    _out({"data": {"orders": {"count": len(mapped), "items": mapped}}}, args.pretty)
+
+
+def _cmd_order_execute(args):
+    """매수/매도 주문 실행."""
+    agent = _create_agent()
+    is_buy = args.action == "buy"
+    code = args.code
+
+    if args.overseas:
+        return _cmd_order_overseas(agent, args, is_buy)
+
+    # 국내주식 주문
+    order_type = _DOMESTIC_ORDER_TYPES.get(args.type, args.type)
+    qty = args.qty
+    price = args.price if args.price else 0
+
+    # 시장가/최유리 계열은 가격 0
+    if order_type in ("01", "03", "05", "06"):
+        price = 0
+
+    # 종목명 조회
+    name = _get_name(agent, code)
+    side_label = "매수" if is_buy else "매도"
+    type_label = {v: k for k, v in _DOMESTIC_ORDER_TYPES.items()}.get(order_type, order_type)
+
+    details = {
+        "종목": f"{code} ({name})" if name else code,
+        "구분": side_label,
+        "주문유형": type_label,
+        "수량": f"{qty:,}주",
+        "가격": f"{price:,}원" if price else "시장가",
+        "거래소": args.exchange.upper(),
+    }
+
+    if not args.yes and not _confirm_order(f"국내주식 {side_label}", details):
+        _out({"cancelled": True, "message": "주문이 취소되었습니다"})
+        return
+
+    try:
+        buy_sell = "BUY" if is_buy else "SELL"
+        result = agent.account_api.order_cash(
+            pdno=code,
+            qty=qty,
+            price=price,
+            buy_sell=buy_sell,
+            order_type=order_type,
+            exchange=args.exchange.upper(),
+        )
+
+        if not result:
+            _out({"error": "주문 실패: 응답 없음"})
+            return
+
+        if result.get("rt_cd") != "0":
+            _out({"error": result.get("msg1", "주문 실패"), "code": result.get("msg_cd")})
+            return
+
+        output = result.get("output", {})
+        _out({"data": {
+            "order": {
+                "status": "accepted",
+                "orderNo": output.get("odno", ""),
+                "time": _fmt_time(output.get("ord_tmd", "")),
+                "side": side_label,
+                "code": code,
+                "name": name,
+                "qty": qty,
+                "price": price if price else "시장가",
+                "type": type_label,
+            }
+        }}, args.pretty)
+
+    except Exception as e:
+        _out({"error": str(e), "code": type(e).__name__})
+        sys.exit(1)
+
+
+def _cmd_order_overseas(agent, args, is_buy):
+    """해외주식 주문 실행."""
+    excd = _OVERSEAS_EXCG_MAP.get(args.overseas.upper(), args.overseas.upper())
+    code = args.code.upper()
+    order_type = _OVERSEAS_ORDER_TYPES.get(args.type, args.type)
+    qty = args.qty
+    price = args.price if args.price else 0
+
+    side_label = "매수" if is_buy else "매도"
+    type_label = {v: k for k, v in _OVERSEAS_ORDER_TYPES.items()}.get(order_type, order_type)
+
+    # MOO/MOC는 매도만 가능
+    if is_buy and order_type in ("31", "33"):
+        _out({"error": f"{type_label} 주문은 매도만 가능합니다"})
+        return
+
+    details = {
+        "거래소": excd,
+        "종목": code,
+        "구분": side_label,
+        "주문유형": type_label,
+        "수량": f"{qty:,}주",
+        "가격": f"{price}" if price else "시장가",
+    }
+
+    if not args.yes and not _confirm_order(f"해외주식 {side_label}", details):
+        _out({"cancelled": True, "message": "주문이 취소되었습니다"})
+        return
+
+    try:
+        if is_buy:
+            result = agent.overseas_api.buy_order(
+                ovrs_excg_cd=excd, pdno=code, qty=qty,
+                price=price, ord_dvsn=order_type,
+            )
+        else:
+            result = agent.overseas_api.sell_order(
+                ovrs_excg_cd=excd, pdno=code, qty=qty,
+                price=price, ord_dvsn=order_type,
+            )
+
+        if not result:
+            _out({"error": "주문 실패: 응답 없음"})
+            return
+
+        if result.get("rt_cd") != "0":
+            _out({"error": result.get("msg1", "주문 실패"), "code": result.get("msg_cd")})
+            return
+
+        output = result.get("output", {})
+        _out({"data": {
+            "order": {
+                "status": "accepted",
+                "orderNo": output.get("odno", ""),
+                "time": _fmt_time(output.get("ord_tmd", "")),
+                "side": side_label,
+                "exchange": excd,
+                "code": code,
+                "qty": qty,
+                "price": price if price else "시장가",
+                "type": type_label,
+            }
+        }}, args.pretty)
+
+    except Exception as e:
+        _out({"error": str(e), "code": type(e).__name__})
+        sys.exit(1)
+
+
+def _cmd_order_cancel(args):
+    """주문 취소."""
+    agent = _create_agent()
+    order_no = args.order_no
+
+    if args.overseas:
+        excd = _OVERSEAS_EXCG_MAP.get(args.overseas.upper(), args.overseas.upper())
+        code = args.code.upper() if args.code else ""
+
+        details = {"거래소": excd, "종목": code, "주문번호": order_no}
+        if not args.yes and not _confirm_order("해외주식 주문 취소", details):
+            _out({"cancelled": True, "message": "취소가 중단되었습니다"})
+            return
+
+        try:
+            result = agent.overseas_api.cancel_order(
+                ovrs_excg_cd=excd, pdno=code,
+                orgn_odno=order_no, qty=args.qty or 0,
+            )
+        except Exception as e:
+            _out({"error": str(e), "code": type(e).__name__})
+            return
+    else:
+        details = {"주문번호": order_no, "수량": f"{args.qty}주" if args.qty else "전량"}
+        if not args.yes and not _confirm_order("주문 취소", details):
+            _out({"cancelled": True, "message": "취소가 중단되었습니다"})
+            return
+
+        try:
+            result = agent.account_api.order_rvsecncl(
+                org_order_no=order_no,
+                qty=args.qty or 0,
+                price=0,
+                order_type="01",
+                cncl_type="취소",
+            )
+        except Exception as e:
+            _out({"error": str(e), "code": type(e).__name__})
+            return
+
+    if not result:
+        _out({"error": "취소 실패: 응답 없음"})
+        return
+
+    if result.get("rt_cd") != "0":
+        _out({"error": result.get("msg1", "취소 실패"), "code": result.get("msg_cd")})
+        return
+
+    output = result.get("output", {})
+    _out({"data": {
+        "cancel": {
+            "status": "accepted",
+            "orderNo": output.get("odno", ""),
+            "origOrderNo": order_no,
+        }
+    }}, args.pretty)
+
+
+def _cmd_order_modify(args):
+    """주문 정정."""
+    agent = _create_agent()
+    order_no = args.order_no
+    price = args.price or 0
+    qty = args.qty or 0
+    order_type = _DOMESTIC_ORDER_TYPES.get(args.type, args.type)
+
+    if args.overseas:
+        excd = _OVERSEAS_EXCG_MAP.get(args.overseas.upper(), args.overseas.upper())
+        code = args.code.upper() if args.code else ""
+
+        details = {
+            "거래소": excd, "종목": code, "주문번호": order_no,
+            "변경가격": f"{price}" if price else "-",
+            "변경수량": f"{qty}주" if qty else "-",
+        }
+        if not args.yes and not _confirm_order("해외주식 주문 정정", details):
+            _out({"cancelled": True, "message": "정정이 중단되었습니다"})
+            return
+
+        try:
+            result = agent.overseas_api.modify_order(
+                ovrs_excg_cd=excd, pdno=code,
+                orgn_odno=order_no, qty=qty, price=price,
+            )
+        except Exception as e:
+            _out({"error": str(e), "code": type(e).__name__})
+            return
+    else:
+        details = {
+            "주문번호": order_no,
+            "변경가격": f"{price:,}원" if price else "-",
+            "변경수량": f"{qty:,}주" if qty else "-",
+            "주문유형": args.type,
+        }
+        if not args.yes and not _confirm_order("주문 정정", details):
+            _out({"cancelled": True, "message": "정정이 중단되었습니다"})
+            return
+
+        try:
+            result = agent.account_api.order_rvsecncl(
+                org_order_no=order_no,
+                qty=qty,
+                price=price,
+                order_type=order_type,
+                cncl_type="정정",
+            )
+        except Exception as e:
+            _out({"error": str(e), "code": type(e).__name__})
+            return
+
+    if not result:
+        _out({"error": "정정 실패: 응답 없음"})
+        return
+
+    if result.get("rt_cd") != "0":
+        _out({"error": result.get("msg1", "정정 실패"), "code": result.get("msg_cd")})
+        return
+
+    output = result.get("output", {})
+    _out({"data": {
+        "modify": {
+            "status": "accepted",
+            "orderNo": output.get("odno", ""),
+            "origOrderNo": order_no,
+        }
+    }}, args.pretty)
+
+
 def cmd_query(args):
     """API 직접 호출 — kis query <domain> <method> [key=value ...]"""
     agent = _create_agent()
@@ -607,6 +1074,27 @@ def cmd_query(args):
         sys.exit(1)
 
 
+def cmd_search(args):
+    """종목 검색 (종목코드 또는 종목명)."""
+    query = args.query
+    limit = args.limit
+
+    results = search_stocks(query, limit=limit)
+    if not results:
+        _out({"data": {"search": {"query": query, "results": [], "count": 0}}})
+        return
+
+    _out({
+        "data": {
+            "search": {
+                "query": query,
+                "count": len(results),
+                "results": results,
+            }
+        }
+    }, args.pretty)
+
+
 def cmd_schema(args):
     """스키마 출력."""
     type_name = args.type
@@ -636,7 +1124,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # price
     p = sub.add_parser("price", help="주식 현재가 조회")
-    p.add_argument("code", help="종목코드 (예: 005930)")
+    p.add_argument("code", help="종목코드 또는 종목명 (예: 005930, 삼성전자)")
     p.add_argument("--daily", action="store_true", help="일별 시세 포함")
     p.add_argument("--period", default="D", help="기간 (D:일, W:주, M:월)")
     p.add_argument("--days", type=int, default=30, help="일수 (기본 30)")
@@ -649,7 +1137,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # orderbook
     p = sub.add_parser("orderbook", help="호가 조회")
-    p.add_argument("code", help="종목코드")
+    p.add_argument("code", help="종목코드 또는 종목명")
     p.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
 
     # overseas
@@ -662,13 +1150,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
 
     # futures
-    p = sub.add_parser("futures", help="선물옵션 시세 조회 (국내/해외)")
-    p.add_argument("code", help="종목코드 (국내: 101S03, 해외: CLM26, ESM26)")
+    p = sub.add_parser("futures", help="선물옵션 시세 조회 (국내/해외/야간)")
+    p.add_argument("code", help="종목코드 (국내: 101S03, 야간: 101W09, 해외: CLM26)")
     p.add_argument(
         "--overseas", action="store_true", help="해외선물 (CME, NYMEX, EUREX 등)"
     )
     p.add_argument("--option", action="store_true", help="해외옵션 (그릭스 포함)")
     p.add_argument("--orderbook", action="store_true", help="호가 포함 (해외선물)")
+    p.add_argument("--night", action="store_true", help="야간선물 모드 (18:00~05:00)")
+    p.add_argument("--balance", action="store_true", help="잔고 조회 (--night와 함께)")
+    p.add_argument("--ccnl", action="store_true", help="체결내역 조회 (--night와 함께)")
     p.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
 
     # trades (거래내역)
@@ -682,6 +1173,63 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--limit", type=int, default=0, help="최대 건수 (0=전체)")
     p.add_argument("--profit", action="store_true", help="기간별 실현손익 모드")
     p.add_argument("--daily-profit", action="store_true", help="일별 손익 합산 (--profit과 함께)")
+    p.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # order (주문)
+    p = sub.add_parser("order", help="주문 실행 (매수/매도/취소/정정/미체결)")
+    order_sub = p.add_subparsers(dest="action", help="주문 액션")
+
+    # order buy
+    ob = order_sub.add_parser("buy", help="매수 주문")
+    ob.add_argument("code", help="종목코드 (국내: 005930, 해외: AAPL)")
+    ob.add_argument("--qty", type=int, required=True, help="주문수량")
+    ob.add_argument("--price", type=float, default=0, help="주문가격 (0=시장가)")
+    ob.add_argument("--type", default="limit", help="주문유형 (limit, market, best, ioc, fok, pre, after, loo, loc)")
+    ob.add_argument("--exchange", default="KRX", help="거래소 (KRX, NXT, SOR)")
+    ob.add_argument("--overseas", default="", help="해외거래소 (NAS, NYS, AMS, HKS, TSE)")
+    ob.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
+    ob.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # order sell
+    os_ = order_sub.add_parser("sell", help="매도 주문")
+    os_.add_argument("code", help="종목코드")
+    os_.add_argument("--qty", type=int, required=True, help="주문수량")
+    os_.add_argument("--price", type=float, default=0, help="주문가격 (0=시장가)")
+    os_.add_argument("--type", default="limit", help="주문유형 (limit, market, best, moo, moc, loo, loc)")
+    os_.add_argument("--exchange", default="KRX", help="거래소 (KRX, NXT, SOR)")
+    os_.add_argument("--overseas", default="", help="해외거래소")
+    os_.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
+    os_.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # order cancel
+    oc = order_sub.add_parser("cancel", help="주문 취소")
+    oc.add_argument("order_no", help="주문번호")
+    oc.add_argument("--code", default="", help="종목코드 (해외주식 필수)")
+    oc.add_argument("--qty", type=int, default=0, help="취소수량 (0=전량)")
+    oc.add_argument("--overseas", default="", help="해외거래소")
+    oc.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
+    oc.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # order modify
+    om = order_sub.add_parser("modify", help="주문 정정")
+    om.add_argument("order_no", help="주문번호")
+    om.add_argument("--code", default="", help="종목코드 (해외주식 필수)")
+    om.add_argument("--qty", type=int, default=0, help="변경수량")
+    om.add_argument("--price", type=float, default=0, help="변경가격")
+    om.add_argument("--type", default="limit", help="주문유형")
+    om.add_argument("--overseas", default="", help="해외거래소")
+    om.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
+    om.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # order list
+    ol = order_sub.add_parser("list", help="미체결 주문 조회")
+    ol.add_argument("--overseas", default="", help="해외거래소 (지정 시 해외 미체결)")
+    ol.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
+
+    # search (종목 검색)
+    p = sub.add_parser("search", help="종목 검색 (코드 또는 이름)")
+    p.add_argument("query", help="검색어 (종목코드 또는 종목명, 예: 삼성, 005930, 카카오)")
+    p.add_argument("--limit", type=int, default=20, help="최대 결과 수 (기본 20)")
     p.add_argument("--pretty", action="store_true", help="사람 읽기용 포맷")
 
     # query (API 직접 호출)
@@ -716,6 +1264,8 @@ def main():
         "overseas": cmd_overseas,
         "futures": cmd_futures,
         "trades": cmd_trades,
+        "order": cmd_order,
+        "search": cmd_search,
         "query": cmd_query,
         "schema": cmd_schema,
     }

--- a/kis_agent/stock/api.py
+++ b/kis_agent/stock/api.py
@@ -25,32 +25,17 @@ def get_kospi200_futures_code(today: Optional[datetime] = None) -> str:
     현재 날짜 기준으로 거래되고 있는 가장 활발한 KOSPI200 선물 종목코드를 반환합니다.
 
     KOSPI200 선물은 3, 6, 9, 12월 만기로 거래되며, 만기일은 매월 두 번째 주 목요일입니다.
-    현재 날짜를 기준으로 가장 가까운 활성 선물 코드를 자동으로 계산합니다.
 
     Args:
         today (Optional[datetime]): 기준 날짜. None이면 현재 날짜 사용
 
     Returns:
-        str: KOSPI200 선물 종목코드 (6자리, 예: "101W09")
-
-    Example:
-        >>> from kis_agent.stock.api import get_kospi200_futures_code
-        >>> from datetime import datetime
-        >>>
-        >>> # 현재 활성 선물 코드
-        >>> current_code = get_kospi200_futures_code()
-        >>> print(current_code)  # "101W09" (2025년 9월물)
-        >>>
-        >>> # 특정 날짜 기준
-        >>> specific_date = datetime(2025, 10, 1)
-        >>> future_code = get_kospi200_futures_code(specific_date)
-        >>> print(future_code)  # "101W12" (2025년 12월물)
+        str: KOSPI200 선물 종목코드 (6자리, 예: "A01606")
 
     Note:
-        - 종목코드 패턴: 101W + MM (MM: 03, 06, 09, 12)
+        - 종목코드 패턴: A016 + YYMM (YY: 연도 끝 2자리, MM: 만기월)
+        - 마스터 파일(fo_idx_code_mts.mst) 기준 코드 체계
         - 만기일: 매월 두 번째 주 목요일 (15:30 마감)
-        - 만기일 지나면 자동으로 다음 만기월로 전환
-        - 12월물 만기 후에는 다음해 3월물로 전환
     """
     if today is None:
         today = datetime.now()
@@ -66,27 +51,30 @@ def get_kospi200_futures_code(today: Optional[datetime] = None) -> str:
     expiry_months = [3, 6, 9, 12]
     current_year = today.year
     current_month = today.month
-
     if current_month in expiry_months:
         expiry_date = get_second_thursday(current_year, current_month)
         if today.date() > expiry_date.date():
+            found = False
             for month in expiry_months:
                 if month > current_month:
-                    expiry = month
+                    expiry_month = month
+                    found = True
                     break
-            else:
-                expiry = 3
+            if not found:
+                expiry_month = 3
         else:
-            expiry = current_month
+            expiry_month = current_month
     else:
+        found = False
         for month in expiry_months:
             if month > current_month:
-                expiry = month
+                expiry_month = month
+                found = True
                 break
-        else:
-            expiry = 3
+        if not found:
+            expiry_month = 3
 
-    return f"101W{expiry:02d}"
+    return f"A016{expiry_month:02d}"
 
 
 class StockAPI(BaseAPI):

--- a/kis_agent/utils/stock_master.py
+++ b/kis_agent/utils/stock_master.py
@@ -1,0 +1,218 @@
+# Created: 2026-04-01
+# Purpose: KRX 종목 마스터 다운로드/캐싱/검색
+# Dependencies: urllib, zipfile (표준 라이브러리만 사용)
+"""
+KRX 종목 마스터 유틸리티
+
+한국투자증권 마스터파일 서버에서 KOSPI/KOSDAQ 전종목 코드+이름을 다운로드하고
+로컬 캐시에 저장한다. 종목코드 또는 종목명(부분 매칭)으로 검색 가능.
+"""
+
+import csv
+import io
+import logging
+import ssl
+import urllib.request
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# 마스터파일 URL
+_MASTER_URLS = {
+    "kospi": "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+    "kosdaq": "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+}
+
+# 캐시 디렉토리
+_CACHE_DIR = Path.home() / ".kis_agent" / "master"
+
+# 메모리 캐시
+_stock_cache: List[Dict[str, str]] = []
+_cache_date: Optional[str] = None
+
+
+def _get_cache_path() -> Path:
+    """캐시 CSV 경로."""
+    return _CACHE_DIR / "stocks.csv"
+
+
+def _download_master(exchange: str) -> List[Dict[str, str]]:
+    """마스터파일 다운로드 및 파싱 (동기)."""
+    url = _MASTER_URLS[exchange]
+
+    # SSL 인증서 검증 비활성화 (한투 서버 호환)
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    with urllib.request.urlopen(url, context=ctx, timeout=30) as resp:
+        content = resp.read()
+
+    # ZIP 압축 해제
+    try:
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
+            raw = zf.read(zf.namelist()[0])
+    except zipfile.BadZipFile:
+        raw = content
+
+    # 파싱: EUC-KR, 고정 폭 (0-8: 단축코드, 21-60: 한글종목명)
+    symbols = []
+    for line in raw.split(b"\n"):
+        if len(line) < 61:
+            continue
+        code = line[0:9].decode("euc-kr", errors="ignore").strip()
+        name = line[21:61].decode("euc-kr", errors="ignore").strip()
+        if len(code) > 6:
+            code = code[-6:]
+        if code and name and len(code) == 6:
+            symbols.append({
+                "code": code,
+                "name": name,
+                "market": "코스피" if exchange == "kospi" else "코스닥",
+            })
+
+    return symbols
+
+
+def _save_cache(stocks: List[Dict[str, str]]) -> None:
+    """CSV로 캐시 저장."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _get_cache_path()
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["code", "name", "market"])
+        writer.writeheader()
+        writer.writerows(stocks)
+    logger.info(f"종목 마스터 캐시 저장: {len(stocks)}개 → {path}")
+
+
+def _load_cache() -> List[Dict[str, str]]:
+    """CSV 캐시 로드."""
+    path = _get_cache_path()
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _is_cache_fresh() -> bool:
+    """캐시가 오늘 날짜인지 확인."""
+    path = _get_cache_path()
+    if not path.exists():
+        return False
+    mtime = datetime.fromtimestamp(path.stat().st_mtime)
+    return mtime.strftime("%Y%m%d") == datetime.now().strftime("%Y%m%d")
+
+
+def load_stocks(force_refresh: bool = False) -> List[Dict[str, str]]:
+    """
+    종목 마스터 로드 (캐시 우선, 하루 1회 갱신).
+
+    Returns:
+        [{"code": "005930", "name": "삼성전자", "market": "코스피"}, ...]
+    """
+    global _stock_cache, _cache_date
+
+    today = datetime.now().strftime("%Y%m%d")
+
+    # 메모리 캐시 히트
+    if _stock_cache and _cache_date == today and not force_refresh:
+        return _stock_cache
+
+    # 파일 캐시 히트
+    if not force_refresh and _is_cache_fresh():
+        _stock_cache = _load_cache()
+        _cache_date = today
+        if _stock_cache:
+            logger.info(f"종목 마스터 캐시 로드: {len(_stock_cache)}개")
+            return _stock_cache
+
+    # 다운로드
+    try:
+        stocks = []
+        for exchange in ("kospi", "kosdaq"):
+            result = _download_master(exchange)
+            stocks.extend(result)
+            logger.info(f"{exchange} 종목 수집: {len(result)}개")
+
+        if stocks:
+            _save_cache(stocks)
+            _stock_cache = stocks
+            _cache_date = today
+        return stocks
+
+    except Exception as e:
+        logger.warning(f"마스터 다운로드 실패: {e}")
+        # 파일 캐시 폴백 (만료되었더라도)
+        cached = _load_cache()
+        if cached:
+            _stock_cache = cached
+            _cache_date = today
+            logger.info(f"만료된 캐시 사용: {len(cached)}개")
+            return cached
+        return []
+
+
+def search(query: str, limit: int = 20) -> List[Dict[str, str]]:
+    """
+    종목코드 또는 종목명으로 검색.
+
+    정확 매칭 → 이름이 검색어로 시작 → 부분 매칭 순으로 정렬.
+
+    Args:
+        query: 검색어 (종목코드 6자리 또는 종목명 부분 매칭)
+        limit: 최대 결과 수
+
+    Returns:
+        [{"code": "005930", "name": "삼성전자", "market": "코스피"}, ...]
+    """
+    stocks = load_stocks()
+    if not stocks:
+        return []
+
+    q = query.strip().upper()
+
+    # 종목코드 정확 매칭 우선
+    for s in stocks:
+        if s["code"] == q:
+            return [s]
+
+    # 종목명 검색: 정확 → 접두사 → 부분 매칭 순서
+    q_lower = query.strip().lower()
+    exact = []
+    prefix = []
+    partial = []
+
+    for s in stocks:
+        name_lower = s["name"].lower()
+        if name_lower == q_lower:
+            exact.append(s)
+        elif name_lower.startswith(q_lower):
+            prefix.append(s)
+        elif q_lower in name_lower or q_lower in s["code"].lower():
+            partial.append(s)
+
+    return (exact + prefix + partial)[:limit]
+
+
+def resolve_code(query: str) -> Optional[str]:
+    """
+    종목코드 또는 종목명을 종목코드로 변환.
+    6자리 숫자면 그대로 반환. 아니면 종목명으로 검색해서 첫 번째 결과 반환.
+
+    Args:
+        query: 종목코드 또는 종목명
+
+    Returns:
+        6자리 종목코드 또는 None
+    """
+    q = query.strip()
+    if len(q) == 6 and q.isdigit():
+        return q
+
+    results = search(q, limit=1)
+    if results:
+        return results[0]["code"]
+    return None

--- a/kis_agent/websocket/ws_agent.py
+++ b/kis_agent/websocket/ws_agent.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 from base64 import b64decode
 from datetime import datetime
 from datetime import time as dt_time
@@ -48,7 +49,15 @@ class WSAgent:
     """다중 구독 웹소켓 에이전트. 종목/지수/선물 동시 구독, 자동 재연결, AES256 처리."""
 
     # 복구 불가능한 에러 패턴 (이 에러 발생 시 재연결 중단)
-    _FATAL_ERROR_PATTERNS = frozenset({"401", "403", "인증", "권한", "만료", "expired"})
+    # 워드 바운더리(\b)로 감싸서 포트 번호 등의 오탐 방지
+    _FATAL_ERROR_PATTERNS = [
+        re.compile(r"\b401\b"),
+        re.compile(r"\b403\b"),
+        re.compile(r"인증"),
+        re.compile(r"권한"),
+        re.compile(r"만료"),
+        re.compile(r"expired", re.IGNORECASE),
+    ]
 
     def __init__(
         self,
@@ -681,7 +690,7 @@ class WSAgent:
         else:
             handler(data, metadata)
 
-    async def _receive_loop(self, websocket):
+    async def _receive_loop(self, websocket) -> str:
         """
         메시지 수신 루프 (별도 Task로 실행)
 
@@ -694,10 +703,13 @@ class WSAgent:
 
         Args:
             websocket: 웹소켓 연결 객체
+
+        Returns:
+            str: 종료 사유 ("disconnected" | "ping_failed" | "connection_closed" |
+                 "cancelled" | "error")
         """
         ping_retry_count = 0
         max_ping_retries = 5
-        recv_timeout = max(90, self.ping_interval * 3)
         last_ping_time = None
         # ping 체크 간격을 ping_interval과 동일하게 설정
         # (이전: 20초 고정 → 조용한 시장에서 불필요한 ping 폭풍 발생)
@@ -733,7 +745,7 @@ class WSAgent:
                             logger.error(
                                 f"ping/pong 타임아웃 {max_ping_retries}회 연속 실패, 재연결 필요"
                             )
-                            break
+                            return "ping_failed"
                         logger.warning(
                             f"ping/pong 타임아웃 ({ping_retry_count}/{max_ping_retries}), 재시도..."
                         )
@@ -745,7 +757,7 @@ class WSAgent:
                             logger.error(
                                 f"ping/pong 실패 {max_ping_retries}회 연속: {e}"
                             )
-                            break
+                            return "ping_failed"
                         logger.warning(
                             f"ping/pong 오류 ({ping_retry_count}/{max_ping_retries}): {e}"
                         )
@@ -756,13 +768,15 @@ class WSAgent:
 
             except ConnectionClosed:
                 logger.warning("웹소켓 연결 종료 (수신 루프)")
-                break
+                return "connection_closed"
             except asyncio.CancelledError:
                 logger.debug("수신 루프 취소됨")
-                break
+                return "cancelled"
             except Exception as e:
                 logger.error(f"수신 루프 오류: {e}")
-                break
+                return "error"
+
+        return "disconnected"
 
     async def connect(self):
         """
@@ -787,16 +801,19 @@ class WSAgent:
 
         reconnect_count = 0
         consecutive_failures = 0  # 연결 성공 없이 연속 실패 횟수
+        should_reconnect = True  # 이번 루프에서 재연결 시도할지 여부
 
         while self.auto_reconnect:
             receive_task = None
+            should_reconnect = True
             try:
                 logger.info(f"웹소켓 연결 시도: {self.url}")
 
+                # 버그4 수정: 라이브러리 자동 ping 비활성화 → _receive_loop의 수동 ping만 사용
                 async with websockets.connect(
                     self.url,
-                    ping_interval=self.ping_interval,
-                    ping_timeout=self.ping_timeout,
+                    ping_interval=None,
+                    ping_timeout=None,
                 ) as websocket:
                     self.ws = websocket
                     self.connected = True
@@ -809,22 +826,48 @@ class WSAgent:
                     # 수신 루프가 시작될 때까지 잠시 대기
                     await asyncio.sleep(0.1)
 
-                    # 모든 구독 요청 전송 (수신 루프와 병렬로 실행)
-                    await self._subscribe_all()
+                    # 버그5 수정: _subscribe_all 중 receive_task 사망 감지
+                    subscribe_task = asyncio.create_task(self._subscribe_all())
+                    done, pending = await asyncio.wait(
+                        [receive_task, subscribe_task],
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
 
-                    # 수신 루프 완료 대기 (연결이 끊어질 때까지)
-                    await receive_task
+                    # 수신 루프가 먼저 끝난 경우 → 구독 태스크 취소
+                    if receive_task in done:
+                        if not subscribe_task.done():
+                            subscribe_task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await subscribe_task
+                        logger.warning("구독 중 수신 루프 종료 감지")
+                    else:
+                        # 구독 완료 → 수신 루프 완료 대기
+                        await receive_task
+
+                    # 버그1 수정: 수신 루프 종료 사유로 재연결 여부 판단
+                    exit_reason = receive_task.result() if receive_task.done() else "unknown"
+                    if exit_reason == "disconnected":
+                        # self.connected=False로 정상 종료 (disconnect() 호출)
+                        should_reconnect = False
+                        logger.info("정상 종료 — 재연결하지 않음")
+                    elif exit_reason == "cancelled":
+                        should_reconnect = False
+                        logger.info("수신 루프 취소됨 — 재연결하지 않음")
+                    else:
+                        # ping_failed, connection_closed, error → 재연결
+                        logger.info(f"수신 루프 종료 사유: {exit_reason} — 재연결 시도")
 
             except Exception as e:
                 error_str = str(e)
                 logger.error(f"웹소켓 오류: {error_str}")
                 consecutive_failures += 1
 
-                # 복구 불가능한 에러 판별
-                is_fatal = any(p in error_str for p in self._FATAL_ERROR_PATTERNS)
+                # 버그6 수정: 정규식 워드 바운더리로 오탐 방지
+                is_fatal = any(p.search(error_str) for p in self._FATAL_ERROR_PATTERNS)
 
                 if is_fatal:
                     # 인증 에러: client가 있으면 1회 갱신 시도
+                    approval_refreshed = False
                     if self.client:
                         try:
                             new_approval_key = self.client.get_ws_approval_key(
@@ -832,29 +875,36 @@ class WSAgent:
                             )
                             if new_approval_key:
                                 self.update_approval_key(new_approval_key)
+                                # 버그2 수정: consecutive_failures 리셋, finally 우회 방지
+                                consecutive_failures = 0
+                                approval_refreshed = True
                                 logger.info("approval_key 갱신 완료. 재연결 시도...")
-                                continue  # 갱신 성공 시 바로 재연결
                         except Exception as refresh_error:
                             logger.error(f"approval_key 갱신 실패: {refresh_error}")
 
-                    # client 없거나 갱신 실패 → 중단
-                    logger.error(
-                        f"복구 불가능한 에러로 재연결 중단: {error_str}"
-                    )
-                    self.auto_reconnect = False
-                    break
+                    if not approval_refreshed:
+                        # client 없거나 갱신 실패 → 중단
+                        logger.error(
+                            f"복구 불가능한 에러로 재연결 중단: {error_str}"
+                        )
+                        self.auto_reconnect = False
+                        should_reconnect = False
 
             finally:
                 self.connected = False
                 self.ws = None
                 self.active_subscriptions.clear()
+                # 버그3 수정: 구독 대기 상태 정리
+                self._pending_subscriptions.clear()
+                self._subscription_results.clear()
+                self._subscription_errors.clear()
                 # 수신 Task 정리
                 if receive_task and not receive_task.done():
                     receive_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await receive_task
 
-            if not self.auto_reconnect:
+            if not self.auto_reconnect or not should_reconnect:
                 break
 
             # 장 마감 체크

--- a/pykis-mcp-server/src/pykis_mcp_server/tools/consolidated_tools.py
+++ b/pykis-mcp-server/src/pykis_mcp_server/tools/consolidated_tools.py
@@ -4,11 +4,28 @@
 각 도구는 query_type 또는 action 파라미터로 세부 기능을 선택합니다.
 """
 
+import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 from ..errors import InvalidParameterError, validate_api_response
 from ..server import get_agent, server
+
+logger = logging.getLogger(__name__)
+
+
+def _inject_stock_name(result: Dict[str, Any], agent, code: str) -> Dict[str, Any]:
+    """API 응답에 종목명을 주입한다. 조회 실패 시 원본 그대로 반환."""
+    try:
+        info = agent.stock_api.search_stock_info(code=code)
+        if info and info.get("output"):
+            o = info["output"]
+            name = o.get("prdt_abrv_name") or o.get("prdt_name")
+            if name:
+                result["_stock_name"] = name
+    except Exception:
+        logger.debug(f"종목명 조회 실패: {code}")
+    return result
 
 
 # =============================================================================
@@ -56,23 +73,29 @@ async def stock_quote(
 
     if query_type == "price":
         result = agent.get_stock_price(code)
-        return validate_api_response(result, "현재가 조회")
+        validated = validate_api_response(result, "현재가 조회")
+        return _inject_stock_name(validated, agent, code)
     elif query_type == "detail":
         result = agent.inquire_price(code, market)
-        return validate_api_response(result, "현재가 상세 조회")
+        validated = validate_api_response(result, "현재가 상세 조회")
+        return _inject_stock_name(validated, agent, code)
     elif query_type == "detail2":
         result = agent.inquire_price_2(code, market)
-        return validate_api_response(result, "현재가 상세 조회 2")
+        validated = validate_api_response(result, "현재가 상세 조회 2")
+        return _inject_stock_name(validated, agent, code)
     elif query_type == "orderbook":
         result = agent.get_orderbook_raw(code)
-        return validate_api_response(result, "호가 조회")
+        validated = validate_api_response(result, "호가 조회")
+        return _inject_stock_name(validated, agent, code)
     elif query_type == "execution":
         result = agent.inquire_ccnl(code, market)
-        return validate_api_response(result, "체결 정보 조회")
+        validated = validate_api_response(result, "체결 정보 조회")
+        return _inject_stock_name(validated, agent, code)
     elif query_type == "time_execution":
         hour = hour or "155900"
         result = agent.inquire_time_itemconclusion(code, hour)
-        return validate_api_response(result, "시간별 체결 조회")
+        validated = validate_api_response(result, "시간별 체결 조회")
+        return _inject_stock_name(validated, agent, code)
 
 
 # =============================================================================
@@ -118,25 +141,27 @@ async def stock_chart(
 
     if timeframe == "minute":
         if date:
-            # 특정일 전체 분봉 (내부 페이지네이션)
             result = agent.get_daily_minute_price(code, date)
-            return validate_api_response(result, f"분봉 조회 ({date})")
+            validated = validate_api_response(result, f"분봉 조회 ({date})")
         else:
-            # 당일 전체 분봉
             result = agent.get_intraday_price(code)
-            return validate_api_response(result, "당일 분봉 조회")
+            validated = validate_api_response(result, "당일 분봉 조회")
     elif timeframe == "daily":
         result = agent.inquire_daily_itemchartprice(code, start_date, end_date)
-        return validate_api_response(result, "일봉 데이터 조회")
+        validated = validate_api_response(result, "일봉 데이터 조회")
     elif timeframe == "daily_30":
         result = agent.inquire_daily_price(code, period)
-        return validate_api_response(result, "최근 30일 조회")
+        validated = validate_api_response(result, "최근 30일 조회")
     elif timeframe == "weekly":
         result = agent.inquire_daily_price(code, "W")
-        return validate_api_response(result, "주봉 데이터 조회")
+        validated = validate_api_response(result, "주봉 데이터 조회")
     elif timeframe == "monthly":
         result = agent.inquire_daily_price(code, "M")
-        return validate_api_response(result, "월봉 데이터 조회")
+        validated = validate_api_response(result, "월봉 데이터 조회")
+    else:
+        raise InvalidParameterError("timeframe", f"유효한 값: {valid_timeframes}")
+
+    return _inject_stock_name(validated, agent, code)
 
 
 # =============================================================================

--- a/pykis-mcp-server/src/pykis_mcp_server/tools/stock_tools.py
+++ b/pykis-mcp-server/src/pykis_mcp_server/tools/stock_tools.py
@@ -1,10 +1,27 @@
 """Stock price and market data MCP tools"""
 
+import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 from ..errors import InvalidParameterError, validate_api_response
 from ..server import get_agent, server
+
+logger = logging.getLogger(__name__)
+
+
+def _inject_stock_name(result: Dict[str, Any], agent, code: str) -> Dict[str, Any]:
+    """API 응답에 종목명을 주입한다."""
+    try:
+        info = agent.stock_api.search_stock_info(code=code)
+        if info and info.get("output"):
+            o = info["output"]
+            name = o.get("prdt_abrv_name") or o.get("prdt_name")
+            if name:
+                result["_stock_name"] = name
+    except Exception:
+        logger.debug(f"종목명 조회 실패: {code}")
+    return result
 
 
 @server.tool()
@@ -25,7 +42,8 @@ async def get_stock_price(code: str) -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.get_stock_price(code)
-    return validate_api_response(result, "주식 현재가 조회")
+    validated = validate_api_response(result, "주식 현재가 조회")
+    return _inject_stock_name(validated, agent, code)
 
 
 @server.tool()
@@ -47,7 +65,8 @@ async def get_daily_price(
 
     agent = get_agent()
     result = agent.inquire_daily_itemchartprice(stock_code, start_date, end_date)
-    return validate_api_response(result, "일봉 데이터 조회")
+    validated = validate_api_response(result, "일봉 데이터 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -69,7 +88,8 @@ async def inquire_daily_price(
 
     agent = get_agent()
     result = agent.inquire_daily_price(stock_code, period, org_adj_prc)
-    return validate_api_response(result, "일자별 시세 조회")
+    validated = validate_api_response(result, "일자별 시세 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -87,7 +107,8 @@ async def get_intraday_price(stock_code: str) -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.get_intraday_price(stock_code)
-    return validate_api_response(result, "당일 분봉 조회")
+    validated = validate_api_response(result, "당일 분봉 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -106,7 +127,8 @@ async def inquire_price(stock_code: str, market: str = "J") -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.inquire_price(stock_code, market)
-    return validate_api_response(result, "현재가 상세 조회")
+    validated = validate_api_response(result, "현재가 상세 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -125,7 +147,8 @@ async def inquire_price_2(stock_code: str, market: str = "J") -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.inquire_price_2(stock_code, market)
-    return validate_api_response(result, "현재가 상세 조회 2")
+    validated = validate_api_response(result, "현재가 상세 조회 2")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -144,7 +167,8 @@ async def inquire_ccnl(stock_code: str, market: str = "J") -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.inquire_ccnl(stock_code, market)
-    return validate_api_response(result, "체결 정보 조회")
+    validated = validate_api_response(result, "체결 정보 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -163,7 +187,8 @@ async def get_stock_ccnl(stock_code: str, market: str = "J") -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.get_stock_ccnl(stock_code, market)
-    return validate_api_response(result, "주식 체결 조회")
+    validated = validate_api_response(result, "주식 체결 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -184,7 +209,8 @@ async def inquire_time_itemconclusion(
 
     agent = get_agent()
     result = agent.inquire_time_itemconclusion(stock_code, hour)
-    return validate_api_response(result, "시간별 체결 조회")
+    validated = validate_api_response(result, "시간별 체결 조회")
+    return _inject_stock_name(validated, agent, stock_code)
 
 
 @server.tool()
@@ -217,11 +243,11 @@ async def get_minute_price(code: str, time_code: str = "093000") -> Dict[str, An
         raise InvalidParameterError("code", "종목코드는 6자리여야 합니다")
 
     agent = get_agent()
-    # deprecated: get_intraday_price로 포워딩
     result = agent.get_intraday_price(code)
-    return validate_api_response(
+    validated = validate_api_response(
         result, "당일 분봉 조회 (deprecated → get_intraday_price)"
     )
+    return _inject_stock_name(validated, agent, code)
 
 
 @server.tool()
@@ -244,7 +270,8 @@ async def get_daily_minute_price(code: str, date: str) -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.get_daily_minute_price(code, date)
-    return validate_api_response(result, "특정일 전체 분봉 조회")
+    validated = validate_api_response(result, "특정일 전체 분봉 조회")
+    return _inject_stock_name(validated, agent, code)
 
 
 @server.tool()
@@ -279,7 +306,8 @@ async def inquire_minute_price(code: str, date: Optional[str] = None) -> Dict[st
 
     agent = get_agent()
     result = agent.get_daily_minute_price(code, date)
-    return validate_api_response(result, "분봉시세조회")
+    validated = validate_api_response(result, "분봉시세조회")
+    return _inject_stock_name(validated, agent, code)
 
 
 @server.tool()
@@ -297,7 +325,8 @@ async def get_orderbook_raw(code: str) -> Dict[str, Any]:
 
     agent = get_agent()
     result = agent.get_orderbook_raw(code)
-    return validate_api_response(result, "호가 조회")
+    validated = validate_api_response(result, "호가 조회")
+    return _inject_stock_name(validated, agent, code)
 
 
 @server.tool()
@@ -319,7 +348,8 @@ async def fetch_minute_data(
 
     agent = get_agent()
     result = agent.fetch_minute_data(code, date, cache_dir)
-    return {"success": True, "data": result}
+    response = {"success": True, "data": result}
+    return _inject_stock_name(response, agent, code)
 
 
 @server.tool()
@@ -338,7 +368,35 @@ async def calculate_support_resistance(code: str, date: str = "") -> Dict[str, A
 
     agent = get_agent()
     result = agent.calculate_support_resistance(code, date)
-    return {"success": True, "data": result}
+    response = {"success": True, "data": result}
+    return _inject_stock_name(response, agent, code)
+
+
+@server.tool()
+async def search_stock(query: str, limit: int = 20) -> Dict[str, Any]:
+    """종목 검색 (종목코드 또는 종목명으로 검색)
+
+    KRX 전종목 마스터를 기반으로 종목코드 또는 종목명 부분 매칭 검색.
+    첫 호출 시 마스터파일 다운로드 (이후 하루 1회 자동 갱신, 로컬 캐시).
+
+    Args:
+        query: 검색어 (종목코드 6자리 또는 종목명, 예: "삼성", "005930", "카카오")
+        limit: 최대 결과 수 (기본 20)
+
+    Returns:
+        Dict: 검색 결과
+            - query: 검색어
+            - count: 결과 수
+            - results: [{"code": "005930", "name": "삼성전자", "market": "코스피"}, ...]
+    """
+    from kis_agent.utils.stock_master import search as _search_stocks
+
+    results = _search_stocks(query, limit=limit)
+    return {
+        "query": query,
+        "count": len(results),
+        "results": results,
+    }
 
 
 @server.tool()


### PR DESCRIPTION
## Summary
- 종목코드 조회 시 종목명 항상 표시 (CLI + MCP 전체)
- 종목명으로 검색/조회 가능 (`kis search 삼성`, `kis price 카카오`)
- KRX 전종목 마스터 다운로드/캐싱 유틸 추가
- WebSocket 6건 버그 수정 (재연결 로직, 이중 ping, 구독 정리 등)
- ruff F841 미사용 변수 정리

## Changes
- `kis_agent/utils/stock_master.py` — KRX 종목 마스터 다운로드/캐싱/검색
- `kis_agent/cli/main.py` — search 서브커맨드, 종목명 resolve, 해외 종목명 조회
- `kis_agent/websocket/ws_agent.py` — 6건 버그 수정
- `kis_agent/stock/api.py` — 미사용 변수 제거
- `pykis-mcp-server/.../consolidated_tools.py` — _inject_stock_name 헬퍼
- `pykis-mcp-server/.../stock_tools.py` — 전 tool 종목명 주입 + search_stock tool

## Test plan
- [x] ruff check 통과
- [x] 관련 테스트 98건 통과
- [x] 종목 검색 실동작 검증 (삼성전자, 카카오, SK하이닉스, NAVER)
- [x] resolve_code 정확도 검증