### PR TITLE
feat(ws,master): add KRX night futures/options realtime WS and futures master utility

### DIFF
--- a/kis_agent/core/agent.py
+++ b/kis_agent/core/agent.py
@@ -14,11 +14,13 @@ from ..stock import (
 )
 from ..stock.interest import InterestStockAPI
 from ..stock.investor_api import StockInvestorAPI
+from ..utils.futures_master import load_futures as _load_futures_master
 from ..utils.sector_code import (
     SECTOR_CODES,
     get_sector_code_by_market,
     get_sector_codes,
 )
+from ..utils.stock_master import load_stocks as _load_stock_master
 from ..websocket.client import KisWebSocket
 from .base_exception_handler import BaseExceptionHandler, exception_handler
 from .client import KISClient
@@ -251,6 +253,31 @@ class Agent(TechnicalAnalysisMixin, MethodDiscoveryMixin, BaseExceptionHandler):
         self.overseas_futures_api = OverseasFutures(
             self.client, self.account_info, _from_agent=True
         )
+
+        # 종목 마스터 사전 로드 (캐시 있으면 즉시 반환, 없으면 백그라운드 다운로드)
+        self._preload_masters()
+
+    def _preload_masters(self) -> None:
+        """종목 마스터 파일 사전 로드.
+
+        캐시가 오늘 날짜면 즉시 반환 (수 ms).
+        캐시가 없거나 오래됐으면 백그라운드 스레드에서 다운로드.
+        실패해도 Agent 초기화를 블로킹하지 않음.
+        """
+        import threading
+
+        def _load():
+            try:
+                stocks = _load_stock_master()
+                futures = _load_futures_master()
+                self.logger.info(
+                    f"종목 마스터 로드 완료: 주식 {len(stocks)}개, 선물옵션 {len(futures)}개"
+                )
+            except Exception as e:
+                self.logger.warning(f"종목 마스터 로드 실패 (무시): {e}")
+
+        thread = threading.Thread(target=_load, daemon=True)
+        thread.start()
 
     @property
     def overseas(self) -> OverseasStockAPI:

--- a/kis_agent/utils/__init__.py
+++ b/kis_agent/utils/__init__.py
@@ -2,6 +2,13 @@
 PyKIS 유틸리티 모듈
 """
 
+from .futures_master import (
+    get_current_futures,
+    get_futures_by_month_type,
+    load_futures,
+    resolve_futures_code,
+    search as search_futures,
+)
 from .sector_code import SECTOR_CODES, get_sector_code_by_market, get_sector_codes
 from .trading_report import TradingReportGenerator, generate_trading_report
 
@@ -11,4 +18,10 @@ __all__ = [
     "get_sector_codes",
     "get_sector_code_by_market",
     "SECTOR_CODES",
+    # 선물옵션 마스터
+    "load_futures",
+    "search_futures",
+    "get_current_futures",
+    "get_futures_by_month_type",
+    "resolve_futures_code",
 ]

--- a/kis_agent/utils/futures_master.py
+++ b/kis_agent/utils/futures_master.py
@@ -1,0 +1,394 @@
+# Created: 2026-04-06
+# Purpose: 선물옵션 종목 마스터 다운로드/캐싱/검색
+# Dependencies: urllib, zipfile (표준 라이브러리만 사용)
+"""
+선물옵션 종목 마스터 유틸리티
+
+한국투자증권 마스터파일 서버에서 지수선물옵션/상품선물옵션 전종목을
+다운로드하고 로컬 캐시에 저장한다.
+단축코드(A01606) 또는 종목명(F 202606)으로 검색 가능.
+
+마스터파일 종류:
+  - fo_idx_code_mts.mst: 지수 선물/옵션 (KOSPI200, 미니, 코스닥150, 위클리 등)
+  - fo_com_code.mst: 상품 선물/옵션 (금, 돈육, 달러 등)
+"""
+
+import csv
+import io
+import logging
+import ssl
+import urllib.request
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+# 마스터파일 URL
+_MASTER_URLS = {
+    "index": "https://new.real.download.dws.co.kr/common/master/fo_idx_code_mts.mst.zip",
+    "commodity": "https://new.real.download.dws.co.kr/common/master/fo_com_code.mst.zip",
+}
+
+# 캐시 디렉토리
+_CACHE_DIR = Path.home() / ".kis_agent" / "master"
+
+# 메모리 캐시
+_futures_cache: List[Dict[str, str]] = []
+_cache_date: Optional[str] = None
+
+# 지수선물옵션 상품종류 코드
+_IDX_TYPE_MAP = {
+    "1": "지수선물",
+    "2": "지수SP",
+    "3": "스타선물",
+    "4": "스타SP",
+    "5": "지수콜옵션",
+    "6": "지수풋옵션",
+    "7": "변동성선물",
+    "8": "변동성SP",
+    "9": "섹터선물",
+    "A": "섹터SP",
+    "B": "미니선물",
+    "C": "미니SP",
+    "D": "미니콜옵션",
+    "E": "미니풋옵션",
+    "J": "코스닥150콜옵션",
+    "K": "코스닥150풋옵션",
+    "L": "위클리콜옵션",
+    "M": "위클리풋옵션",
+}
+
+# 월물구분코드
+_MONTH_TYPE_MAP = {
+    "0": "연결선물",
+    "1": "최근월물",
+    "2": "차근월물",
+    "3": "차차근월물",
+    "4": "차차차근월물",
+}
+
+
+def _get_cache_path() -> Path:
+    """캐시 CSV 경로."""
+    return _CACHE_DIR / "futures.csv"
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """SSL 컨텍스트 (한투 서버 호환)."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _download_index_master() -> List[Dict[str, str]]:
+    """지수 선물옵션 마스터파일 다운로드 및 파싱.
+
+    파일 형식: 파이프(|) 구분
+    상품종류|단축코드|표준코드|한글종목명|ATM구분|행사가|월물구분코드|기초자산단축코드|기초자산명
+    """
+    url = _MASTER_URLS["index"]
+    with urllib.request.urlopen(url, context=_ssl_context(), timeout=30) as resp:
+        content = resp.read()
+
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        raw = zf.read(zf.namelist()[0])
+
+    symbols = []
+    for line in raw.decode("cp949").strip().split("\n"):
+        parts = line.split("|")
+        if len(parts) < 9:
+            continue
+
+        product_type = parts[0].strip()
+        symbols.append({
+            "code": parts[1].strip(),
+            "std_code": parts[2].strip(),
+            "name": parts[3].strip(),
+            "atm": parts[4].strip(),
+            "strike": parts[5].strip(),
+            "month_type": parts[6].strip(),
+            "underlying_code": parts[7].strip(),
+            "underlying_name": parts[8].strip(),
+            "product_type": product_type,
+            "product_type_name": _IDX_TYPE_MAP.get(product_type, product_type),
+            "market": "index",
+        })
+
+    return symbols
+
+
+def _download_commodity_master() -> List[Dict[str, str]]:
+    """상품 선물옵션 마스터파일 다운로드 및 파싱.
+
+    파일 형식: 고정폭 + 파이프 혼합
+    상품구분(1) + 상품종류(1) + 단축코드(9) + 표준코드(12) + 한글종목명(32)
+    + ... + 월물구분코드(1) + 기초자산단축코드(3) + 기초자산명(...)
+    """
+    url = _MASTER_URLS["commodity"]
+    with urllib.request.urlopen(url, context=_ssl_context(), timeout=30) as resp:
+        content = resp.read()
+
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        raw = zf.read(zf.namelist()[0])
+
+    symbols = []
+    for line in raw.decode("cp949").strip().split("\n"):
+        if len(line) < 55:
+            continue
+
+        product_group = line[0:1]
+        product_type = line[1:2]
+        code = line[2:11].strip()
+        std_code = line[11:23].strip()
+        name = line[23:55].strip()
+
+        # 나머지 부분에서 월물구분코드, 기초자산 추출
+        rest = line[55:].lstrip()
+        month_type = rest[8:9] if len(rest) > 8 else ""
+        underlying_code = rest[9:12].strip() if len(rest) > 11 else ""
+        underlying_name = rest[12:].strip() if len(rest) > 12 else ""
+
+        symbols.append({
+            "code": code,
+            "std_code": std_code,
+            "name": name,
+            "atm": "",
+            "strike": "",
+            "month_type": month_type,
+            "underlying_code": underlying_code,
+            "underlying_name": underlying_name,
+            "product_type": f"{product_group}{product_type}",
+            "product_type_name": f"상품{product_type}",
+            "market": "commodity",
+        })
+
+    return symbols
+
+
+def _save_cache(symbols: List[Dict[str, str]]) -> None:
+    """CSV로 캐시 저장."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _get_cache_path()
+    fieldnames = [
+        "code", "std_code", "name", "atm", "strike",
+        "month_type", "underlying_code", "underlying_name",
+        "product_type", "product_type_name", "market",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(symbols)
+    logger.info(f"선물옵션 마스터 캐시 저장: {len(symbols)}개 → {path}")
+
+
+def _load_cache() -> List[Dict[str, str]]:
+    """CSV 캐시 로드."""
+    path = _get_cache_path()
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _is_cache_fresh() -> bool:
+    """캐시가 오늘 날짜인지 확인."""
+    path = _get_cache_path()
+    if not path.exists():
+        return False
+    mtime = datetime.fromtimestamp(path.stat().st_mtime)
+    return mtime.strftime("%Y%m%d") == datetime.now().strftime("%Y%m%d")
+
+
+def load_futures(
+    force_refresh: bool = False,
+    markets: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
+    """
+    선물옵션 마스터 로드 (캐시 우선, 하루 1회 갱신).
+
+    Args:
+        force_refresh: 캐시 무시하고 새로 다운로드
+        markets: 로드할 시장 ["index", "commodity"]. None이면 전체.
+
+    Returns:
+        [{"code": "A01606", "name": "F 202606", "product_type_name": "지수선물", ...}, ...]
+    """
+    global _futures_cache, _cache_date
+
+    today = datetime.now().strftime("%Y%m%d")
+
+    # 메모리 캐시 히트
+    if _futures_cache and _cache_date == today and not force_refresh:
+        return _filter_markets(_futures_cache, markets)
+
+    # 파일 캐시 히트
+    if not force_refresh and _is_cache_fresh():
+        _futures_cache = _load_cache()
+        _cache_date = today
+        if _futures_cache:
+            logger.info(f"선물옵션 마스터 캐시 로드: {len(_futures_cache)}개")
+            return _filter_markets(_futures_cache, markets)
+
+    # 다운로드
+    try:
+        symbols: List[Dict[str, str]] = []
+
+        idx_result = _download_index_master()
+        symbols.extend(idx_result)
+        logger.info(f"지수선물옵션 종목 수집: {len(idx_result)}개")
+
+        com_result = _download_commodity_master()
+        symbols.extend(com_result)
+        logger.info(f"상품선물옵션 종목 수집: {len(com_result)}개")
+
+        if symbols:
+            _save_cache(symbols)
+            _futures_cache = symbols
+            _cache_date = today
+        return _filter_markets(symbols, markets)
+
+    except Exception as e:
+        logger.warning(f"선물옵션 마스터 다운로드 실패: {e}")
+        cached = _load_cache()
+        if cached:
+            _futures_cache = cached
+            _cache_date = today
+            logger.info(f"만료된 캐시 사용: {len(cached)}개")
+            return _filter_markets(cached, markets)
+        return []
+
+
+def _filter_markets(
+    symbols: List[Dict[str, str]],
+    markets: Optional[List[str]],
+) -> List[Dict[str, str]]:
+    """시장 필터링."""
+    if not markets:
+        return symbols
+    return [s for s in symbols if s.get("market") in markets]
+
+
+def search(
+    query: str,
+    limit: int = 20,
+    product_types: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
+    """
+    단축코드 또는 종목명으로 검색.
+
+    Args:
+        query: 검색어 (단축코드 또는 종목명 부분 매칭)
+        limit: 최대 결과 수
+        product_types: 필터링할 상품종류 이름 리스트
+                      (예: ["지수선물", "미니선물"])
+
+    Returns:
+        매칭된 종목 리스트
+    """
+    symbols = load_futures()
+    if not symbols:
+        return []
+
+    # 상품종류 필터
+    if product_types:
+        pt_lower = [pt.lower() for pt in product_types]
+        symbols = [
+            s for s in symbols
+            if s.get("product_type_name", "").lower() in pt_lower
+        ]
+
+    q = query.strip().upper()
+
+    # 단축코드 정확 매칭
+    for s in symbols:
+        if s["code"].upper() == q:
+            return [s]
+
+    # 종목명 검색
+    q_lower = query.strip().lower()
+    exact, prefix, partial = [], [], []
+
+    for s in symbols:
+        name_lower = s["name"].lower()
+        code_lower = s["code"].lower()
+        if name_lower == q_lower:
+            exact.append(s)
+        elif name_lower.startswith(q_lower) or code_lower.startswith(q_lower):
+            prefix.append(s)
+        elif q_lower in name_lower or q_lower in code_lower:
+            partial.append(s)
+
+    return (exact + prefix + partial)[:limit]
+
+
+def get_current_futures(
+    product: Literal["kospi200", "mini", "kosdaq150"] = "kospi200",
+) -> Optional[Dict[str, str]]:
+    """
+    현재 근월물 선물 종목 조회.
+
+    Args:
+        product: 상품 종류
+
+    Returns:
+        근월물 종목 정보 dict 또는 None
+    """
+    type_map = {
+        "kospi200": "지수선물",
+        "mini": "미니선물",
+        "kosdaq150": "섹터선물",
+    }
+    product_type_name = type_map.get(product, "지수선물")
+
+    symbols = load_futures()
+    candidates = [
+        s for s in symbols
+        if s.get("product_type_name") == product_type_name
+        and s.get("month_type") == "1"  # 최근월물
+    ]
+
+    return candidates[0] if candidates else None
+
+
+def get_futures_by_month_type(
+    month_type: str = "1",
+    product_type_name: str = "지수선물",
+) -> List[Dict[str, str]]:
+    """
+    월물구분코드로 선물 종목 필터링.
+
+    Args:
+        month_type: "0"=연결, "1"=최근월물, "2"=차근월물, ...
+        product_type_name: 상품종류명
+
+    Returns:
+        매칭된 종목 리스트
+    """
+    symbols = load_futures()
+    return [
+        s for s in symbols
+        if s.get("month_type") == month_type
+        and s.get("product_type_name") == product_type_name
+    ]
+
+
+def resolve_futures_code(query: str) -> Optional[str]:
+    """
+    종목코드 또는 종목명을 단축코드로 변환.
+
+    Args:
+        query: 단축코드, 종목명, 또는 "F 202606" 형태
+
+    Returns:
+        단축코드 (예: "A01606") 또는 None
+    """
+    q = query.strip()
+
+    # 이미 단축코드 형태면 그대로
+    results = search(q, limit=1)
+    if results:
+        return results[0]["code"]
+    return None

--- a/kis_agent/websocket/ws_agent.py
+++ b/kis_agent/websocket/ws_agent.py
@@ -23,10 +23,14 @@ logger = logging.getLogger(__name__)
 MARKET_CLOSE_TIME = dt_time(15, 30)
 
 
-def _is_after_market_close() -> bool:
+def _is_after_market_close(has_night_session: bool = False) -> bool:
     """장 마감 후인지 확인 (KRX: 15:30 이후, NXT: 20:00 이후)
 
     NXT 세션 (16:00-20:00)은 마감으로 처리하지 않음
+    야간선물/옵션 구독 시 야간 세션 (18:00-05:00)도 마감으로 처리하지 않음
+
+    Args:
+        has_night_session: 야간선물/옵션 구독이 포함되어 있는지 여부
     """
     kst = pytz.timezone("Asia/Seoul")
     now = datetime.now(kst)
@@ -41,8 +45,24 @@ def _is_after_market_close() -> bool:
     if nxt_start <= current_time <= nxt_end:
         return False  # NXT 세션 중이므로 마감 아님
 
-    # 15:30 이후 체크 (NXT 세션 제외)
+    # 야간선물/옵션 세션 체크 (18:00-05:00 익일)
+    if has_night_session:
+        night_start = dt_time(18, 0)
+        night_end = dt_time(5, 0)
+        if current_time >= night_start or current_time <= night_end:
+            return False  # 야간 세션 중이므로 마감 아님
+
+    # 15:30 이후 체크 (NXT/야간 세션 제외)
     return current_time > MARKET_CLOSE_TIME
+
+
+# 야간선물/옵션 SubscriptionType 목록
+_NIGHT_SESSION_TYPES = {
+    "H0MFCNT0",  # NIGHT_FUTURES_TRADE
+    "H0MFASP0",  # NIGHT_FUTURES_ASK_BID
+    "H0EUCNT0",  # NIGHT_OPTION_TRADE
+    "H0EUASP0",  # NIGHT_OPTION_ASK_BID
+}
 
 
 class WSAgent:
@@ -126,6 +146,13 @@ class WSAgent:
             "last_message_time": None,
         }
 
+    def _ws_closed(self) -> bool:
+        """WebSocket 연결이 닫혔는지 확인 (websockets v14+ 호환)"""
+        if self.ws is None:
+            return True
+        # websockets v14+: close_code가 설정되면 연결이 닫힌 것
+        return self.ws.close_code is not None
+
     def update_approval_key(self, new_approval_key: str) -> None:
         """
         approval_key 갱신 (토큰 재발급 시 사용)
@@ -198,7 +225,7 @@ class WSAgent:
         self.subscriptions[sub_id] = subscription
 
         # 연결되어 있으면 비동기 태스크 생성 (결과 추적)
-        if self.connected and self.ws and not self.ws.closed:
+        if self.connected and self.ws and not self._ws_closed():
             task = asyncio.create_task(self._send_subscription(subscription))
             # 태스크 완료 시 실패 로깅을 위한 콜백 추가
             task.add_done_callback(lambda t: self._on_subscription_task_done(t, sub_id))
@@ -246,7 +273,7 @@ class WSAgent:
         self.subscriptions[sub_id] = subscription
 
         # 연결되어 있으면 구독 요청 및 응답 대기
-        if self.connected and self.ws and not self.ws.closed:
+        if self.connected and self.ws and not self._ws_closed():
             success = await self._send_subscription(subscription)
             if not success:
                 # 구독 실패 시 등록 제거
@@ -273,7 +300,7 @@ class WSAgent:
         subscription = self.subscriptions[sub_id]
 
         # 구독 해제 메시지 전송 (연결 상태 상세 검증)
-        if self.connected and self.ws and not self.ws.closed:
+        if self.connected and self.ws and not self._ws_closed():
             asyncio.create_task(self._send_unsubscription(subscription))
 
         # 구독 정보 삭제
@@ -342,7 +369,7 @@ class WSAgent:
         for attempt in range(max_retries):
             try:
                 # 연결 상태 상세 검증
-                if not self.ws or self.ws.closed:
+                if not self.ws or self._ws_closed():
                     logger.error(f"구독 요청 실패 - 웹소켓 연결 없음: {sub_id}")
                     return False
 
@@ -461,7 +488,7 @@ class WSAgent:
             sub_id = f"{subscription.sub_type.value}_{subscription.key}"
 
             # 연결 상태 확인
-            if not self.ws or self.ws.closed:
+            if not self.ws or self._ws_closed():
                 logger.error(
                     f"구독 중단 - 연결 끊김 (성공: {len(results['success'])}, 남은: {total - idx})"
                 )
@@ -793,8 +820,13 @@ class WSAgent:
         Raises:
             Exception: 연결 실패 또는 메시지 처리 오류
         """
-        # 장 마감 후 연결 시도 차단 (EOD 모드)
-        if _is_after_market_close():
+        # 야간선물/옵션 구독 여부 확인
+        has_night = any(
+            sub.sub_type.value in _NIGHT_SESSION_TYPES
+            for sub in self.subscriptions.values()
+        )
+        # 장 마감 후 연결 시도 차단 (EOD 모드) — 야간 세션 구독 시 예외
+        if _is_after_market_close(has_night_session=has_night):
             logger.info("장 마감 시간 - WebSocket 연결 시도 차단 (EOD 모드)")
             self.auto_reconnect = False
             return
@@ -907,8 +939,8 @@ class WSAgent:
             if not self.auto_reconnect or not should_reconnect:
                 break
 
-            # 장 마감 체크
-            if _is_after_market_close():
+            # 장 마감 체크 (야간 세션 구독 시 예외)
+            if _is_after_market_close(has_night_session=has_night):
                 logger.info("장 마감 시간 - WebSocket 재연결 중단 (EOD 모드)")
                 self.auto_reconnect = False
                 break

--- a/kis_agent/websocket/ws_helpers.py
+++ b/kis_agent/websocket/ws_helpers.py
@@ -226,6 +226,203 @@ class RealtimeDataParser:
         "exch_cls_code",
     ]
 
+    # KRX 야간선물 체결 필드 (H0MFCNT0) [실시간-064]
+    NIGHT_FUTURES_TRADE_FIELDS = [
+        "futs_shrn_iscd",
+        "bsop_hour",
+        "futs_prdy_vrss",
+        "prdy_vrss_sign",
+        "futs_prdy_ctrt",
+        "futs_prpr",
+        "futs_oprc",
+        "futs_hgpr",
+        "futs_lwpr",
+        "last_cnqn",
+        "acml_vol",
+        "acml_tr_pbmn",
+        "hts_thpr",
+        "mrkt_basis",
+        "dprt",
+        "nmsc_fctn_stpl_prc",
+        "fmsc_fctn_stpl_prc",
+        "spead_prc",
+        "hts_otst_stpl_qty",
+        "otst_stpl_qty_icdc",
+        "oprc_hour",
+        "oprc_vrss_prpr_sign",
+        "oprc_vrss_nmix_prpr",
+        "hgpr_hour",
+        "hgpr_vrss_prpr_sign",
+        "hgpr_vrss_nmix_prpr",
+        "lwpr_hour",
+        "lwpr_vrss_prpr_sign",
+        "lwpr_vrss_nmix_prpr",
+        "shnu_rate",
+        "cttr",
+        "esdg",
+        "otst_stpl_rgbf_qty_icdc",
+        "thpr_basis",
+        "futs_askp1",
+        "futs_bidp1",
+        "askp_rsqn1",
+        "bidp_rsqn1",
+        "seln_cntg_csnu",
+        "shnu_cntg_csnu",
+        "ntby_cntg_csnu",
+        "seln_cntg_smtn",
+        "shnu_cntg_smtn",
+        "total_askp_rsqn",
+        "total_bidp_rsqn",
+        "prdy_vol_vrss_acml_vol_rate",
+        "dynm_mxpr",
+        "dynm_llam",
+        "dynm_prc_limt_yn",
+    ]
+
+    # KRX 야간선물 호가 필드 (H0MFASP0) [실시간-065]
+    NIGHT_FUTURES_ORDERBOOK_FIELDS = [
+        "futs_shrn_iscd",
+        "bsop_hour",
+        "futs_askp1",
+        "futs_askp2",
+        "futs_askp3",
+        "futs_askp4",
+        "futs_askp5",
+        "futs_bidp1",
+        "futs_bidp2",
+        "futs_bidp3",
+        "futs_bidp4",
+        "futs_bidp5",
+        "askp_csnu1",
+        "askp_csnu2",
+        "askp_csnu3",
+        "askp_csnu4",
+        "askp_csnu5",
+        "bidp_csnu1",
+        "bidp_csnu2",
+        "bidp_csnu3",
+        "bidp_csnu4",
+        "bidp_csnu5",
+        "askp_rsqn1",
+        "askp_rsqn2",
+        "askp_rsqn3",
+        "askp_rsqn4",
+        "askp_rsqn5",
+        "bidp_rsqn1",
+        "bidp_rsqn2",
+        "bidp_rsqn3",
+        "bidp_rsqn4",
+        "bidp_rsqn5",
+        "total_askp_csnu",
+        "total_bidp_csnu",
+        "total_askp_rsqn",
+        "total_bidp_rsqn",
+        "total_askp_rsqn_icdc",
+        "total_bidp_rsqn_icdc",
+    ]
+
+    # KRX 야간옵션 체결 필드 (H0EUCNT0) [실시간-032]
+    NIGHT_OPTION_TRADE_FIELDS = [
+        "optn_shrn_iscd",
+        "bsop_hour",
+        "optn_prpr",
+        "prdy_vrss_sign",
+        "optn_prdy_vrss",
+        "prdy_ctrt",
+        "optn_oprc",
+        "optn_hgpr",
+        "optn_lwpr",
+        "last_cnqn",
+        "acml_vol",
+        "acml_tr_pbmn",
+        "hts_thpr",
+        "hts_otst_stpl_qty",
+        "otst_stpl_qty_icdc",
+        "oprc_hour",
+        "oprc_vrss_prpr_sign",
+        "oprc_vrss_nmix_prpr",
+        "hgpr_hour",
+        "hgpr_vrss_prpr_sign",
+        "hgpr_vrss_nmix_prpr",
+        "lwpr_hour",
+        "lwpr_vrss_prpr_sign",
+        "lwpr_vrss_nmix_prpr",
+        "shnu_rate",
+        "prmm_val",
+        "invl_val",
+        "tmvl_val",
+        "delta",
+        "gama",
+        "vega",
+        "theta",
+        "rho",
+        "hts_ints_vltl",
+        "esdg",
+        "otst_stpl_rgbf_qty_icdc",
+        "thpr_basis",
+        "unas_hist_vltl",
+        "cttr",
+        "dprt",
+        "mrkt_basis",
+        "optn_askp1",
+        "optn_bidp1",
+        "askp_rsqn1",
+        "bidp_rsqn1",
+        "seln_cntg_csnu",
+        "shnu_cntg_csnu",
+        "ntby_cntg_csnu",
+        "seln_cntg_smtn",
+        "shnu_cntg_smtn",
+        "total_askp_rsqn",
+        "total_bidp_rsqn",
+        "prdy_vol_vrss_acml_vol_rate",
+        "dynm_mxpr",
+        "dynm_prc_limt_yn",
+        "dynm_llam",
+    ]
+
+    # KRX 야간옵션 호가 필드 (H0EUASP0) [실시간-033]
+    NIGHT_OPTION_ORDERBOOK_FIELDS = [
+        "optn_shrn_iscd",
+        "bsop_hour",
+        "optn_askp1",
+        "optn_askp2",
+        "optn_askp3",
+        "optn_askp4",
+        "optn_askp5",
+        "optn_bidp1",
+        "optn_bidp2",
+        "optn_bidp3",
+        "optn_bidp4",
+        "optn_bidp5",
+        "askp_csnu1",
+        "askp_csnu2",
+        "askp_csnu3",
+        "askp_csnu4",
+        "askp_csnu5",
+        "bidp_csnu1",
+        "bidp_csnu2",
+        "bidp_csnu3",
+        "bidp_csnu4",
+        "bidp_csnu5",
+        "askp_rsqn1",
+        "askp_rsqn2",
+        "askp_rsqn3",
+        "askp_rsqn4",
+        "askp_rsqn5",
+        "bidp_rsqn1",
+        "bidp_rsqn2",
+        "bidp_rsqn3",
+        "bidp_rsqn4",
+        "bidp_rsqn5",
+        "total_askp_csnu",
+        "total_bidp_csnu",
+        "total_askp_rsqn",
+        "total_bidp_rsqn",
+        "total_askp_rsqn_icdc",
+        "total_bidp_rsqn_icdc",
+    ]
+
     # NXT 프로그램매매 필드 (H0NXPGM0)
     PROGRAM_TRADE_NXT_FIELDS = [
         "mksc_shrn_iscd",
@@ -260,6 +457,11 @@ class RealtimeDataParser:
             ST.PROGRAM_TRADE_NXT: cls.PROGRAM_TRADE_NXT_FIELDS,
             ST.MARKET_OPERATION_NXT: cls.MARKET_OPERATION_NXT_FIELDS,
             ST.MEMBER_TRADE_NXT: cls.MEMBER_TRADE_FIELDS,
+            # KRX 야간선물/옵션
+            ST.NIGHT_FUTURES_TRADE: cls.NIGHT_FUTURES_TRADE_FIELDS,
+            ST.NIGHT_FUTURES_ASK_BID: cls.NIGHT_FUTURES_ORDERBOOK_FIELDS,
+            ST.NIGHT_OPTION_TRADE: cls.NIGHT_OPTION_TRADE_FIELDS,
+            ST.NIGHT_OPTION_ASK_BID: cls.NIGHT_OPTION_ORDERBOOK_FIELDS,
         }
 
         fields = field_map.get(sub_type)
@@ -298,6 +500,27 @@ class RealtimeDataParser:
             "vrss",
             "nmix",
             "icdc",
+            # 선물/옵션 공통
+            "askp",
+            "bidp",
+            "basis",
+            "dprt",
+            "esdg",
+            "cttr",
+            "stpl",
+            # 옵션 그릭스/가치
+            "delta",
+            "gama",
+            "vega",
+            "theta",
+            "rho",
+            "prmm_val",
+            "invl_val",
+            "tmvl_val",
+            "vltl",
+            "spead",
+            "mxpr",
+            "llam",
         ]
 
         for keyword in numeric_keywords:
@@ -349,6 +572,26 @@ class RealtimeDataParser:
         """지수 예상체결 데이터 파싱"""
 
         return cls.parse(SubscriptionType.INDEX_EXPECTED, values)
+
+    @classmethod
+    def parse_night_futures_trade(cls, values: List[str]) -> Dict[str, Any]:
+        """야간선물 체결 데이터 파싱"""
+        return cls.parse(SubscriptionType.NIGHT_FUTURES_TRADE, values)
+
+    @classmethod
+    def parse_night_futures_orderbook(cls, values: List[str]) -> Dict[str, Any]:
+        """야간선물 호가 데이터 파싱"""
+        return cls.parse(SubscriptionType.NIGHT_FUTURES_ASK_BID, values)
+
+    @classmethod
+    def parse_night_option_trade(cls, values: List[str]) -> Dict[str, Any]:
+        """야간옵션 체결 데이터 파싱"""
+        return cls.parse(SubscriptionType.NIGHT_OPTION_TRADE, values)
+
+    @classmethod
+    def parse_night_option_orderbook(cls, values: List[str]) -> Dict[str, Any]:
+        """야간옵션 호가 데이터 파싱"""
+        return cls.parse(SubscriptionType.NIGHT_OPTION_ASK_BID, values)
 
 
 class RealtimeDataStore:
@@ -411,6 +654,18 @@ class RealtimeDataStore:
 
     def get_member_trade(self, code: str) -> Optional[Dict[str, Any]]:
         return self.get(code, SubscriptionType.MEMBER_TRADE)
+
+    def get_night_futures_trade(self, code: str) -> Optional[Dict[str, Any]]:
+        return self.get(code, SubscriptionType.NIGHT_FUTURES_TRADE)
+
+    def get_night_futures_orderbook(self, code: str) -> Optional[Dict[str, Any]]:
+        return self.get(code, SubscriptionType.NIGHT_FUTURES_ASK_BID)
+
+    def get_night_option_trade(self, code: str) -> Optional[Dict[str, Any]]:
+        return self.get(code, SubscriptionType.NIGHT_OPTION_TRADE)
+
+    def get_night_option_orderbook(self, code: str) -> Optional[Dict[str, Any]]:
+        return self.get(code, SubscriptionType.NIGHT_OPTION_ASK_BID)
 
     def get_history(
         self, code: str, sub_type: Any, limit: Optional[int] = None

--- a/kis_agent/websocket/ws_types.py
+++ b/kis_agent/websocket/ws_types.py
@@ -37,11 +37,17 @@ class SubscriptionType(Enum):
     PROGRAM_TRADE = "H0STPGM0"  # 프로그램매매 실시간 (KRX)
     MEMBER_TRADE = "H0MBCNT0"  # 회원사별 실시간 매매동향
 
-    # 선물/옵션
+    # 선물/옵션 (주간)
     FUTURES_TRADE = "H0CFCNT0"  # 선물 체결
     FUTURES_ASK_BID = "H0CFASP0"  # 선물 호가
     OPTION_TRADE = "H0OPCNT0"  # 옵션 체결
     OPTION_ASK_BID = "H0OPASP0"  # 옵션 호가
+
+    # KRX 야간선물/옵션
+    NIGHT_FUTURES_TRADE = "H0MFCNT0"  # 야간선물 체결 [실시간-064]
+    NIGHT_FUTURES_ASK_BID = "H0MFASP0"  # 야간선물 호가 [실시간-065]
+    NIGHT_OPTION_TRADE = "H0EUCNT0"  # 야간옵션 체결 [실시간-032]
+    NIGHT_OPTION_ASK_BID = "H0EUASP0"  # 야간옵션 호가 [실시간-033]
 
     # 해외
     OVERSEAS_STOCK = "HDFSCNT0"  # 해외주식 체결

--- a/tests/unit/test_futures_master.py
+++ b/tests/unit/test_futures_master.py
@@ -1,0 +1,230 @@
+"""
+선물옵션 마스터 유틸리티 테스트
+
+다운로드 모킹, 캐싱, 검색, 근월물 조회 테스트
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kis_agent.utils.futures_master import (
+    _IDX_TYPE_MAP,
+    _download_index_master,
+    _filter_markets,
+    get_current_futures,
+    get_futures_by_month_type,
+    load_futures,
+    resolve_futures_code,
+    search,
+)
+
+# 테스트용 샘플 데이터
+SAMPLE_SYMBOLS = [
+    {
+        "code": "A01606",
+        "std_code": "KR4A01660005",
+        "name": "F 202606",
+        "atm": "",
+        "strike": "00000.00",
+        "month_type": "1",
+        "underlying_code": "2001",
+        "underlying_name": "KOSPI200",
+        "product_type": "1",
+        "product_type_name": "지수선물",
+        "market": "index",
+    },
+    {
+        "code": "A01609",
+        "std_code": "KR4A01690002",
+        "name": "F 202609",
+        "atm": "",
+        "strike": "00000.00",
+        "month_type": "2",
+        "underlying_code": "2001",
+        "underlying_name": "KOSPI200",
+        "product_type": "1",
+        "product_type_name": "지수선물",
+        "market": "index",
+    },
+    {
+        "code": "A05604",
+        "std_code": "KR4A05640003",
+        "name": "미니F 202604",
+        "atm": "",
+        "strike": "00000.00",
+        "month_type": "1",
+        "underlying_code": "2001",
+        "underlying_name": "KOSPI200",
+        "product_type": "B",
+        "product_type_name": "미니선물",
+        "market": "index",
+    },
+    {
+        "code": "201MA350",
+        "std_code": "KR4201MA3500",
+        "name": "C 202606 350.0",
+        "atm": "3",
+        "strike": "00350.00",
+        "month_type": "1",
+        "underlying_code": "2001",
+        "underlying_name": "KOSPI200",
+        "product_type": "5",
+        "product_type_name": "지수콜옵션",
+        "market": "index",
+    },
+    {
+        "code": "GC2604",
+        "std_code": "KR4GC2604001",
+        "name": "금F 202604",
+        "atm": "",
+        "strike": "",
+        "month_type": "1",
+        "underlying_code": "GC",
+        "underlying_name": "금",
+        "product_type": "11",
+        "product_type_name": "상품1",
+        "market": "commodity",
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """각 테스트 전 메모리 캐시 초기화"""
+    import kis_agent.utils.futures_master as fm
+    fm._futures_cache = []
+    fm._cache_date = None
+    yield
+
+
+class TestFilterMarkets:
+    def test_no_filter(self):
+        result = _filter_markets(SAMPLE_SYMBOLS, None)
+        assert len(result) == len(SAMPLE_SYMBOLS)
+
+    def test_index_only(self):
+        result = _filter_markets(SAMPLE_SYMBOLS, ["index"])
+        assert all(s["market"] == "index" for s in result)
+        assert len(result) == 4
+
+    def test_commodity_only(self):
+        result = _filter_markets(SAMPLE_SYMBOLS, ["commodity"])
+        assert len(result) == 1
+        assert result[0]["code"] == "GC2604"
+
+
+class TestSearch:
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_exact_code_match(self, mock_load):
+        results = search("A01606")
+        assert len(results) == 1
+        assert results[0]["code"] == "A01606"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_name_search(self, mock_load):
+        results = search("F 2026")
+        assert len(results) >= 2
+        assert results[0]["code"] == "A01606"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_partial_name(self, mock_load):
+        results = search("미니")
+        assert len(results) == 1
+        assert results[0]["code"] == "A05604"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_product_type_filter(self, mock_load):
+        results = search("F", product_types=["지수선물"])
+        assert all(s["product_type_name"] == "지수선물" for s in results)
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_empty_query(self, mock_load):
+        results = search("NONEXISTENT")
+        assert len(results) == 0
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_limit(self, mock_load):
+        results = search("F", limit=1)
+        assert len(results) == 1
+
+
+class TestGetCurrentFutures:
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_kospi200_current(self, mock_load):
+        result = get_current_futures("kospi200")
+        assert result is not None
+        assert result["code"] == "A01606"
+        assert result["month_type"] == "1"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_mini_current(self, mock_load):
+        result = get_current_futures("mini")
+        assert result is not None
+        assert result["code"] == "A05604"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=[])
+    def test_empty_returns_none(self, mock_load):
+        result = get_current_futures("kospi200")
+        assert result is None
+
+
+class TestGetFuturesByMonthType:
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_nearest_month(self, mock_load):
+        results = get_futures_by_month_type("1", "지수선물")
+        assert len(results) == 1
+        assert results[0]["code"] == "A01606"
+
+    @patch("kis_agent.utils.futures_master.load_futures", return_value=SAMPLE_SYMBOLS)
+    def test_next_month(self, mock_load):
+        results = get_futures_by_month_type("2", "지수선물")
+        assert len(results) == 1
+        assert results[0]["code"] == "A01609"
+
+
+class TestResolveFuturesCode:
+    @patch("kis_agent.utils.futures_master.search")
+    def test_resolve_by_name(self, mock_search):
+        mock_search.return_value = [{"code": "A01606", "name": "F 202606"}]
+        assert resolve_futures_code("F 202606") == "A01606"
+
+    @patch("kis_agent.utils.futures_master.search")
+    def test_resolve_by_code(self, mock_search):
+        mock_search.return_value = [{"code": "A01606", "name": "F 202606"}]
+        assert resolve_futures_code("A01606") == "A01606"
+
+    @patch("kis_agent.utils.futures_master.search")
+    def test_resolve_not_found(self, mock_search):
+        mock_search.return_value = []
+        assert resolve_futures_code("INVALID") is None
+
+
+class TestIdxTypeMap:
+    def test_all_types_defined(self):
+        expected_types = ["1", "2", "3", "4", "5", "6", "7", "8",
+                          "9", "A", "B", "C", "D", "E", "J", "K", "L", "M"]
+        for t in expected_types:
+            assert t in _IDX_TYPE_MAP
+
+
+class TestDownloadIntegration:
+    """실제 다운로드 통합 테스트 (네트워크 필요)"""
+
+    @pytest.mark.slow
+    def test_download_index_master(self):
+        symbols = _download_index_master()
+        assert len(symbols) > 100
+        # KOSPI200 선물이 있어야 함
+        kospi_futures = [s for s in symbols if s["product_type"] == "1"]
+        assert len(kospi_futures) >= 3
+
+    @pytest.mark.slow
+    def test_load_futures_full(self):
+        symbols = load_futures(force_refresh=True)
+        assert len(symbols) > 100
+
+        # 근월물이 있어야 함
+        cur = get_current_futures()
+        assert cur is not None
+        assert cur["month_type"] == "1"

--- a/tests/unit/test_ws_night_futures_options.py
+++ b/tests/unit/test_ws_night_futures_options.py
@@ -1,0 +1,397 @@
+"""
+KRX 야간선물/옵션 웹소켓 실시간 데이터 테스트
+
+SubscriptionType enum, 필드 파싱, 데이터 저장소 테스트
+"""
+
+import pytest
+
+from kis_agent.websocket import (
+    RealtimeDataParser,
+    RealtimeDataStore,
+    SubscriptionType,
+    WSAgent,
+)
+
+
+class TestNightSubscriptionType:
+    """야간선물/옵션 SubscriptionType enum 테스트"""
+
+    def test_night_futures_trade(self):
+        assert SubscriptionType.NIGHT_FUTURES_TRADE.value == "H0MFCNT0"
+
+    def test_night_futures_ask_bid(self):
+        assert SubscriptionType.NIGHT_FUTURES_ASK_BID.value == "H0MFASP0"
+
+    def test_night_option_trade(self):
+        assert SubscriptionType.NIGHT_OPTION_TRADE.value == "H0EUCNT0"
+
+    def test_night_option_ask_bid(self):
+        assert SubscriptionType.NIGHT_OPTION_ASK_BID.value == "H0EUASP0"
+
+
+class TestNightFuturesTradeParser:
+    """야간선물 체결 파서 테스트 [실시간-064]"""
+
+    def _make_values(self):
+        """48개 필드 샘플 데이터"""
+        return [
+            "101V06",       # futs_shrn_iscd
+            "190215",       # bsop_hour
+            "1.50",         # futs_prdy_vrss
+            "2",            # prdy_vrss_sign
+            "0.41",         # futs_prdy_ctrt
+            "367.35",       # futs_prpr
+            "366.00",       # futs_oprc
+            "368.00",       # futs_hgpr
+            "365.50",       # futs_lwpr
+            "3",            # last_cnqn
+            "12345",        # acml_vol
+            "4530000000",   # acml_tr_pbmn
+            "367.50",       # hts_thpr
+            "0.15",         # mrkt_basis
+            "0.04",         # dprt
+            "367.00",       # nmsc_fctn_stpl_prc
+            "368.00",       # fmsc_fctn_stpl_prc
+            "1.00",         # spead_prc
+            "50000",        # hts_otst_stpl_qty
+            "100",          # otst_stpl_qty_icdc
+            "180000",       # oprc_hour
+            "2",            # oprc_vrss_prpr_sign
+            "1.35",         # oprc_vrss_nmix_prpr
+            "183000",       # hgpr_hour
+            "2",            # hgpr_vrss_prpr_sign
+            "0.65",         # hgpr_vrss_nmix_prpr
+            "181500",       # lwpr_hour
+            "5",            # lwpr_vrss_prpr_sign
+            "1.85",         # lwpr_vrss_nmix_prpr
+            "52.30",        # shnu_rate
+            "105.20",       # cttr
+            "0.02",         # esdg
+            "50",           # otst_stpl_rgbf_qty_icdc
+            "0.10",         # thpr_basis
+            "367.40",       # futs_askp1
+            "367.30",       # futs_bidp1
+            "24",           # askp_rsqn1
+            "21",           # bidp_rsqn1
+            "5000",         # seln_cntg_csnu
+            "5100",         # shnu_cntg_csnu
+            "100",          # ntby_cntg_csnu
+            "6000",         # seln_cntg_smtn
+            "6100",         # shnu_cntg_smtn
+            "120",          # total_askp_rsqn
+            "115",          # total_bidp_rsqn
+            "85.30",        # prdy_vol_vrss_acml_vol_rate
+            "380.00",       # dynm_mxpr
+            "355.00",       # dynm_llam
+            "N",            # dynm_prc_limt_yn
+        ]
+
+    def test_parse_night_futures_trade(self):
+        values = self._make_values()
+        result = RealtimeDataParser.parse_night_futures_trade(values)
+
+        assert result["futs_shrn_iscd"] == "101V06"
+        assert result["futs_prpr"] == 367.35
+        assert result["acml_vol"] == 12345
+        assert result["futs_askp1"] == 367.40
+        assert result["futs_bidp1"] == 367.30
+        assert result["dynm_prc_limt_yn"] == "N"
+
+    def test_parse_via_generic(self):
+        values = self._make_values()
+        result = RealtimeDataParser.parse(
+            SubscriptionType.NIGHT_FUTURES_TRADE, values
+        )
+        assert result["futs_prpr"] == 367.35
+
+    def test_field_count(self):
+        assert len(RealtimeDataParser.NIGHT_FUTURES_TRADE_FIELDS) == 49
+
+
+class TestNightFuturesOrderbookParser:
+    """야간선물 호가 파서 테스트 [실시간-065]"""
+
+    def _make_values(self):
+        """36개 필드 샘플 데이터"""
+        return [
+            "101V06",   # futs_shrn_iscd
+            "190215",   # bsop_hour
+            "367.35",   # futs_askp1
+            "367.40",   # futs_askp2
+            "367.45",   # futs_askp3
+            "0.00",     # futs_askp4
+            "0.00",     # futs_askp5
+            "367.30",   # futs_bidp1
+            "367.25",   # futs_bidp2
+            "367.20",   # futs_bidp3
+            "0.00",     # futs_bidp4
+            "0.00",     # futs_bidp5
+            "10",       # askp_csnu1
+            "8",        # askp_csnu2
+            "5",        # askp_csnu3
+            "0",        # askp_csnu4
+            "0",        # askp_csnu5
+            "12",       # bidp_csnu1
+            "9",        # bidp_csnu2
+            "6",        # bidp_csnu3
+            "0",        # bidp_csnu4
+            "0",        # bidp_csnu5
+            "24",       # askp_rsqn1
+            "21",       # askp_rsqn2
+            "15",       # askp_rsqn3
+            "0",        # askp_rsqn4
+            "0",        # askp_rsqn5
+            "28",       # bidp_rsqn1
+            "20",       # bidp_rsqn2
+            "10",       # bidp_rsqn3
+            "0",        # bidp_rsqn4
+            "0",        # bidp_rsqn5
+            "23",       # total_askp_csnu
+            "27",       # total_bidp_csnu
+            "60",       # total_askp_rsqn
+            "58",       # total_bidp_rsqn
+            "5",        # total_askp_rsqn_icdc
+            "-3",       # total_bidp_rsqn_icdc
+        ]
+
+    def test_parse_night_futures_orderbook(self):
+        values = self._make_values()
+        result = RealtimeDataParser.parse_night_futures_orderbook(values)
+
+        assert result["futs_shrn_iscd"] == "101V06"
+        assert result["futs_askp1"] == 367.35
+        assert result["futs_bidp1"] == 367.30
+        assert result["total_askp_rsqn"] == 60
+        assert result["total_bidp_rsqn"] == 58
+
+    def test_field_count(self):
+        assert len(RealtimeDataParser.NIGHT_FUTURES_ORDERBOOK_FIELDS) == 38
+
+
+class TestNightOptionTradeParser:
+    """야간옵션 체결 파서 테스트 [실시간-032]"""
+
+    def _make_values(self):
+        """53개 필드 샘플 데이터"""
+        return [
+            "101W9000",     # optn_shrn_iscd
+            "190215",       # bsop_hour
+            "3.50",         # optn_prpr
+            "2",            # prdy_vrss_sign
+            "0.20",         # optn_prdy_vrss
+            "6.06",         # prdy_ctrt
+            "3.40",         # optn_oprc
+            "3.65",         # optn_hgpr
+            "3.30",         # optn_lwpr
+            "5",            # last_cnqn
+            "2500",         # acml_vol
+            "87500000",     # acml_tr_pbmn
+            "3.48",         # hts_thpr
+            "8000",         # hts_otst_stpl_qty
+            "50",           # otst_stpl_qty_icdc
+            "180000",       # oprc_hour
+            "2",            # oprc_vrss_prpr_sign
+            "0.10",         # oprc_vrss_nmix_prpr
+            "183000",       # hgpr_hour
+            "2",            # hgpr_vrss_prpr_sign
+            "0.15",         # hgpr_vrss_nmix_prpr
+            "181500",       # lwpr_hour
+            "5",            # lwpr_vrss_prpr_sign
+            "0.20",         # lwpr_vrss_nmix_prpr
+            "55.00",        # shnu_rate
+            "2.80",         # prmm_val
+            "0.70",         # invl_val
+            "2.10",         # tmvl_val
+            "0.45",         # delta
+            "0.08",         # gama
+            "0.12",         # vega
+            "-0.05",        # theta
+            "0.01",         # rho
+            "18.50",        # hts_ints_vltl
+            "0.02",         # esdg
+            "30",           # otst_stpl_rgbf_qty_icdc
+            "0.02",         # thpr_basis
+            "15.20",        # unas_hist_vltl
+            "110.50",       # cttr
+            "0.57",         # dprt
+            "0.05",         # mrkt_basis
+            "3.55",         # optn_askp1
+            "3.45",         # optn_bidp1
+            "15",           # askp_rsqn1
+            "18",           # bidp_rsqn1
+            "1200",         # seln_cntg_csnu
+            "1300",         # shnu_cntg_csnu
+            "100",          # ntby_cntg_csnu
+            "1500",         # seln_cntg_smtn
+            "1600",         # shnu_cntg_smtn
+            "80",           # total_askp_rsqn
+            "85",           # total_bidp_rsqn
+            "75.50",        # prdy_vol_vrss_acml_vol_rate
+            "5.00",         # dynm_mxpr
+            "N",            # dynm_prc_limt_yn
+            "1.50",         # dynm_llam
+        ]
+
+    def test_parse_night_option_trade(self):
+        values = self._make_values()
+        result = RealtimeDataParser.parse_night_option_trade(values)
+
+        assert result["optn_shrn_iscd"] == "101W9000"
+        assert result["optn_prpr"] == 3.50
+        assert result["delta"] == 0.45
+        assert result["theta"] == -0.05
+        assert result["hts_ints_vltl"] == 18.50
+        assert result["optn_askp1"] == 3.55
+
+    def test_field_count(self):
+        assert len(RealtimeDataParser.NIGHT_OPTION_TRADE_FIELDS) == 56
+
+
+class TestNightOptionOrderbookParser:
+    """야간옵션 호가 파서 테스트 [실시간-033]"""
+
+    def _make_values(self):
+        """36개 필드 샘플 데이터"""
+        return [
+            "101W9000",     # optn_shrn_iscd
+            "190215",       # bsop_hour
+            "3.55",         # optn_askp1
+            "3.60",         # optn_askp2
+            "3.65",         # optn_askp3
+            "3.70",         # optn_askp4
+            "3.75",         # optn_askp5
+            "3.45",         # optn_bidp1
+            "3.40",         # optn_bidp2
+            "3.35",         # optn_bidp3
+            "3.30",         # optn_bidp4
+            "3.25",         # optn_bidp5
+            "5",            # askp_csnu1
+            "4",            # askp_csnu2
+            "3",            # askp_csnu3
+            "2",            # askp_csnu4
+            "1",            # askp_csnu5
+            "6",            # bidp_csnu1
+            "5",            # bidp_csnu2
+            "4",            # bidp_csnu3
+            "3",            # bidp_csnu4
+            "2",            # bidp_csnu5
+            "15",           # askp_rsqn1
+            "12",           # askp_rsqn2
+            "10",           # askp_rsqn3
+            "8",            # askp_rsqn4
+            "5",            # askp_rsqn5
+            "18",           # bidp_rsqn1
+            "14",           # bidp_rsqn2
+            "11",           # bidp_rsqn3
+            "9",            # bidp_rsqn4
+            "6",            # bidp_rsqn5
+            "15",           # total_askp_csnu
+            "20",           # total_bidp_csnu
+            "50",           # total_askp_rsqn
+            "58",           # total_bidp_rsqn
+            "3",            # total_askp_rsqn_icdc
+            "-2",           # total_bidp_rsqn_icdc
+        ]
+
+    def test_parse_night_option_orderbook(self):
+        values = self._make_values()
+        result = RealtimeDataParser.parse_night_option_orderbook(values)
+
+        assert result["optn_shrn_iscd"] == "101W9000"
+        assert result["optn_askp1"] == 3.55
+        assert result["optn_bidp1"] == 3.45
+        assert result["total_askp_rsqn"] == 50
+        assert result["total_bidp_rsqn"] == 58
+
+    def test_field_count(self):
+        assert len(RealtimeDataParser.NIGHT_OPTION_ORDERBOOK_FIELDS) == 38
+
+
+class TestNightDataStore:
+    """야간선물/옵션 데이터 저장소 테스트"""
+
+    def test_night_futures_trade_store(self):
+        store = RealtimeDataStore()
+        data = {"futs_prpr": 367.35, "acml_vol": 12345}
+        store.update(SubscriptionType.NIGHT_FUTURES_TRADE, "101V06", data)
+
+        result = store.get_night_futures_trade("101V06")
+        assert result["futs_prpr"] == 367.35
+
+    def test_night_futures_orderbook_store(self):
+        store = RealtimeDataStore()
+        data = {"futs_askp1": 367.40, "futs_bidp1": 367.30}
+        store.update(SubscriptionType.NIGHT_FUTURES_ASK_BID, "101V06", data)
+
+        result = store.get_night_futures_orderbook("101V06")
+        assert result["futs_askp1"] == 367.40
+
+    def test_night_option_trade_store(self):
+        store = RealtimeDataStore()
+        data = {"optn_prpr": 3.50, "delta": 0.45}
+        store.update(SubscriptionType.NIGHT_OPTION_TRADE, "101W9000", data)
+
+        result = store.get_night_option_trade("101W9000")
+        assert result["optn_prpr"] == 3.50
+
+    def test_night_option_orderbook_store(self):
+        store = RealtimeDataStore()
+        data = {"optn_askp1": 3.55, "optn_bidp1": 3.45}
+        store.update(SubscriptionType.NIGHT_OPTION_ASK_BID, "101W9000", data)
+
+        result = store.get_night_option_orderbook("101W9000")
+        assert result["optn_askp1"] == 3.55
+
+    def test_night_store_returns_none_for_missing(self):
+        store = RealtimeDataStore()
+        assert store.get_night_futures_trade("NONE") is None
+        assert store.get_night_futures_orderbook("NONE") is None
+        assert store.get_night_option_trade("NONE") is None
+        assert store.get_night_option_orderbook("NONE") is None
+
+
+class TestNightWSAgentSubscription:
+    """WSAgent 야간 구독 테스트"""
+
+    def test_subscribe_night_futures(self):
+        agent = WSAgent(approval_key="test_key")
+        sub_id = agent.subscribe(
+            SubscriptionType.NIGHT_FUTURES_TRADE, "101V06"
+        )
+        assert sub_id == "H0MFCNT0_101V06"
+        assert sub_id in agent.subscriptions
+
+    def test_subscribe_night_futures_orderbook(self):
+        agent = WSAgent(approval_key="test_key")
+        sub_id = agent.subscribe(
+            SubscriptionType.NIGHT_FUTURES_ASK_BID, "101V06"
+        )
+        assert sub_id == "H0MFASP0_101V06"
+
+    def test_subscribe_night_option(self):
+        agent = WSAgent(approval_key="test_key")
+        sub_id = agent.subscribe(
+            SubscriptionType.NIGHT_OPTION_TRADE, "101W9000"
+        )
+        assert sub_id == "H0EUCNT0_101W9000"
+
+    def test_subscribe_night_option_orderbook(self):
+        agent = WSAgent(approval_key="test_key")
+        sub_id = agent.subscribe(
+            SubscriptionType.NIGHT_OPTION_ASK_BID, "101W9000"
+        )
+        assert sub_id == "H0EUASP0_101W9000"
+
+    def test_subscribe_multiple_night_types(self):
+        """야간선물 체결+호가 동시 구독"""
+        agent = WSAgent(approval_key="test_key")
+        id1 = agent.subscribe(SubscriptionType.NIGHT_FUTURES_TRADE, "101V06")
+        id2 = agent.subscribe(SubscriptionType.NIGHT_FUTURES_ASK_BID, "101V06")
+        id3 = agent.subscribe(SubscriptionType.NIGHT_OPTION_TRADE, "101W9000")
+        id4 = agent.subscribe(SubscriptionType.NIGHT_OPTION_ASK_BID, "101W9000")
+
+        assert len(agent.subscriptions) == 4
+        assert all(
+            sid in agent.subscriptions for sid in [id1, id2, id3, id4]
+        )


### PR DESCRIPTION
## Summary
- KRX 야간선물/옵션 실시간 웹소켓 4종 추가 (체결+호가)
- 선물옵션 종목 마스터 다운로드/캐싱/검색 유틸리티 내장
- Agent 생성 시 마스터 파일 자동 사전 로드 (백그라운드)

## Changes
- `ws_types.py`: NIGHT_FUTURES_TRADE/ASK_BID, NIGHT_OPTION_TRADE/ASK_BID enum
- `ws_helpers.py`: 필드 정의 4종, 파서/스토어, numeric_keywords 확장
- `ws_agent.py`: 야간 세션 EOD 예외, websockets v16 호환 (ws.closed → close_code)
- `utils/futures_master.py`: fo_idx/fo_com 마스터 다운로드/캐싱/검색
- `core/agent.py`: _preload_masters() 백그라운드 스레드
- 테스트 41개 통과 (신규 23 + 18)

## Verified
- 실시간 수신 확인: A01606 (F 202606) 30초간 54건 (체결 3 + 호가 51)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)