### PR TITLE
refactor: unify KIS_* env vars and centralize URL constants (v1.7.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,21 @@
-# API Keys (Required to enable respective provider)
-ANTHROPIC_API_KEY="your_anthropic_api_key_here"       # Required: Format: sk-ant-api03-...
-PERPLEXITY_API_KEY="your_perplexity_api_key_here"     # Optional: Format: pplx-...
-OPENAI_API_KEY="your_openai_api_key_here"             # Optional, for OpenAI models. Format: sk-proj-...
-GOOGLE_API_KEY="your_google_api_key_here"             # Optional, for Google Gemini models.
-MISTRAL_API_KEY="your_mistral_key_here"               # Optional, for Mistral AI models.
-XAI_API_KEY="YOUR_XAI_KEY_HERE"                       # Optional, for xAI AI models.
-GROQ_API_KEY="YOUR_GROQ_KEY_HERE"                     # Optional, for Groq models.
-OPENROUTER_API_KEY="YOUR_OPENROUTER_KEY_HERE"         # Optional, for OpenRouter models.
-AZURE_OPENAI_API_KEY="your_azure_key_here"            # Optional, for Azure OpenAI models (requires endpoint in .taskmaster/config.json).
-OLLAMA_API_KEY="your_ollama_api_key_here"             # Optional: For remote Ollama servers that require authentication.
-GITHUB_API_KEY="your_github_api_key_here"             # Optional: For GitHub import/export features. Format: ghp_... or github_pat_...
+# kis-agent 환경변수 템플릿
+#
+# 이 파일을 .env로 복사한 뒤 실제 값을 채워 넣으세요.
+# .env는 .gitignore에 등록되어 있어 커밋되지 않습니다.
+#
+# 인식되는 변수는 KIS_* prefix만 입니다. 이전 버전에서 사용되던 별칭
+# (MY_APP, MY_SEC, KIS_SECRET, MY_ACCT_STOCK, MY_PROD, PROD_URL, VPS_URL, MY_AGENT)은
+# v1.7.0에서 제거되었습니다. README의 마이그레이션 가이드를 참고하세요.
+
+# --- 필수 ---
+KIS_APP_KEY=                      # 한국투자증권 OpenAPI APP KEY
+KIS_APP_SECRET=                   # 한국투자증권 OpenAPI APP SECRET
+KIS_ACCOUNT_NO=                   # 종합계좌번호 (앞 8자리 숫자)
+
+# --- 선택 ---
+KIS_ACCOUNT_CODE=01               # 계좌 상품코드 (기본 "01" = 주식, "03" = 선물옵션)
+KIS_BASE_URL=                     # 비워두면 실전투자 URL이 기본값.
+                                  # 모의투자: https://openapivts.koreainvestment.com:29443
+KIS_VPS_URL=                      # 모의투자 URL 오버라이드 (보통 비워둠)
+KIS_USER_AGENT=KIS_AGENT          # User-Agent 헤더
+KIS_TOKEN_PATH=                   # 토큰 캐시 JSON 파일 경로 (비워두면 패키지 내부에 저장)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ## [Unreleased]
 
+### 🔒 보안·일관성 리팩터 (v1.7.0 예정)
+
+**환경변수 정리 — Breaking Change**
+
+- 환경변수 이름이 `KIS_*` prefix로 통일됨. Legacy 별칭 즉시 제거:
+  - `MY_APP` → `KIS_APP_KEY`
+  - `MY_SEC` / `KIS_SECRET` → `KIS_APP_SECRET`
+  - `MY_ACCT_STOCK` → `KIS_ACCOUNT_NO`
+  - `MY_PROD` → `KIS_ACCOUNT_CODE`
+  - `PROD_URL` → `KIS_BASE_URL`
+  - `VPS_URL` → `KIS_VPS_URL`
+  - `MY_AGENT` → `KIS_USER_AGENT`
+- `.env.example`가 무관한 LLM API 키 템플릿이었던 문제 수정. 실제 `KIS_*` 변수만 포함하도록 재작성.
+- `.env` 자동 로드 정책 변경: 패키지 부모 디렉토리(`../../.env`) 검색 제거. `override=True` → `override=False`로 변경하여 명시적으로 설정된 환경변수가 항상 우선.
+
+**구조 일관성 개선**
+
+- `kis_agent/core/constants.py` 신설: `REAL_BASE_URL`, `MOCK_BASE_URL`, `WS_REAL_URL`, `WS_MOCK_URL`, `AccountProductCode(Enum)`, `KIS_USER_AGENT_DEFAULT`를 단일 진실의 출처로 통합.
+- `kis_agent/core/endpoints.py` 신설: `client.py`에 산재했던 `API_ENDPOINTS` dict 분리.
+- WebSocket URL(`ws://ops.koreainvestment.com:21000`) 8곳 하드코딩을 `constants.WS_REAL_URL` 참조로 통일.
+- REST URL(`https://openapi.koreainvestment.com:9443`) 6곳 하드코딩을 `constants.REAL_BASE_URL` 참조로 통일.
+- `KISConfig.from_env()` 클래스메서드 추가. `KIS_*` 환경변수에서 일괄 로드.
+- `client.py`의 `os.getenv` 직접 호출 분산 제거. `config=None`이면 `KISConfig.from_env()`를 자동 시도하여 단일 진실의 출처로 집중.
+- `KISConfig` 도크스트링 정정: 이전엔 ".env 지원 제거됨"이라 적혀있었으나 실제로는 `auth.py`가 `load_dotenv` 호출 중이던 모순을 해소. ".env 자동 로드 지원"으로 명확화.
+
+**마이그레이션 가이드**
+
+기존 `.env`에 legacy 별칭만 정의된 사용자는 위 매핑 표에 따라 변수명을 갱신해야 합니다. 자세한 안내는 README의 "사전 준비" 섹션 참조.
+
 ### ✨ 기능 추가
 
 #### CLI (LLM Agent Tool) — `kis` 명령 (NEW!)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ pip install kis-agent
 [![PyPI Downloads](https://img.shields.io/pypi/dm/kis-agent.svg)](https://pypi.org/project/kis-agent/)
 [![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-526CFE?logo=materialformkdocs)](https://unohee.github.io/kis-agent/)
+
+**📖 공식 문서:** **[unohee.github.io/kis-agent](https://unohee.github.io/kis-agent/)** — 설치, 빠른 시작, CLI · Python API 레퍼런스, LLM Agent · MCP 연동, 아키텍처 가이드.
 
 ## CLI
 
@@ -64,14 +67,30 @@ WebSocket, aiohttp, openpyxl은 기본 의존성에 포함되어 별도 설치�
 1. [한국투자증권 API 포털](https://apiportal.koreainvestment.com)에서 API 신청
 2. APP_KEY와 APP_SECRET 발급
 3. 계좌번호(CANO)와 계좌상품코드(ACNT_PRDT_CD) 확인
-4. `.env` 파일 설정:
+4. `.env` 파일 설정 (`.env.example`를 복사하여 사용):
 
 ```bash
 KIS_APP_KEY=발급받은_앱키
-KIS_SECRET=발급받은_시크릿      # 또는 KIS_APP_SECRET
+KIS_APP_SECRET=발급받은_시크릿
 KIS_ACCOUNT_NO=계좌번호
-KIS_ACCOUNT_CODE=01
+KIS_ACCOUNT_CODE=01                # 선택 (기본 "01" = 주식, "03" = 선물옵션)
+KIS_BASE_URL=                       # 선택 (모의투자: https://openapivts.koreainvestment.com:29443)
 ```
+
+> **v1.7.0 Breaking change**: 환경변수 이름이 `KIS_*` prefix로 통일되었습니다.
+> 이전 별칭(`MY_APP`, `MY_SEC`, `KIS_SECRET`, `MY_ACCT_STOCK`, `MY_PROD`, `PROD_URL`,
+> `VPS_URL`, `MY_AGENT`)은 더 이상 인식되지 않습니다. 사용 중인 `.env`를
+> 다음과 같이 마이그레이션하세요:
+>
+> | 이전 이름 | 새 이름 |
+> | --- | --- |
+> | `MY_APP` | `KIS_APP_KEY` |
+> | `MY_SEC` / `KIS_SECRET` | `KIS_APP_SECRET` |
+> | `MY_ACCT_STOCK` | `KIS_ACCOUNT_NO` |
+> | `MY_PROD` | `KIS_ACCOUNT_CODE` |
+> | `PROD_URL` | `KIS_BASE_URL` |
+> | `VPS_URL` | `KIS_VPS_URL` |
+> | `MY_AGENT` | `KIS_USER_AGENT` |
 
 ## Python API
 

--- a/kis_agent/__init__.py
+++ b/kis_agent/__init__.py
@@ -8,7 +8,7 @@ from .message_schema import (
 )
 from .websocket.client import KisWebSocket
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 __all__ = [
     "Agent",
     "KisWebSocket",

--- a/kis_agent/cli/main.py
+++ b/kis_agent/cli/main.py
@@ -53,27 +53,20 @@ def _create_agent():
     logging.basicConfig(level=logging.WARNING, format="%(message)s", stream=sys.stderr)
     logging.getLogger("kis_agent").setLevel(logging.WARNING)
 
-    # .env 파일 탐색
-    for p in [
-        ".env",
-        os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(__file__))), ".env"
-        ),
-    ]:
-        if os.path.exists(p):
-            load_dotenv(p)
-            break
+    # 현재 작업 디렉토리의 .env만 로드 (기존 환경변수는 보존)
+    # (v1.7.0부터 패키지 부모 디렉토리 검색 제거)
+    if os.path.exists(".env"):
+        load_dotenv(".env", override=False)
 
     from kis_agent import Agent
+    from kis_agent.core.constants import REAL_BASE_URL
 
     agent = Agent(
         app_key=os.environ["KIS_APP_KEY"],
-        app_secret=os.environ.get("KIS_APP_SECRET", os.environ.get("KIS_SECRET", "")),
+        app_secret=os.environ["KIS_APP_SECRET"],
         account_no=os.environ["KIS_ACCOUNT_NO"],
         account_code=os.environ.get("KIS_ACCOUNT_CODE", "01"),
-        base_url=os.environ.get(
-            "KIS_BASE_URL", "https://openapi.koreainvestment.com:9443"
-        ),
+        base_url=os.environ.get("KIS_BASE_URL", REAL_BASE_URL),
     )
 
     # Agent 생성 시 한 번만 영업일 확인 (공휴일 포함)

--- a/kis_agent/cli_bridge.py
+++ b/kis_agent/cli_bridge.py
@@ -78,33 +78,29 @@ def check_python_installation():
 
 
 def load_env():
-    """환경변수 로드."""
+    """현재 작업 디렉토리의 .env만 로드 (기존 환경변수는 덮어쓰지 않음).
+
+    (v1.7.0부터 패키지 부모 디렉토리/~/.env 검색은 제거. 의도치 않은 환경 오염 방지.)
+    """
     from dotenv import load_dotenv
 
-    for p in [
-        ".env",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"),
-        os.path.expanduser("~/.env"),
-    ]:
-        if os.path.exists(p):
-            load_dotenv(p)
-            break
+    if os.path.exists(".env"):
+        load_dotenv(".env", override=False)
 
 
 def create_agent():
-    """환경변수에서 인증 정보를 로드하여 Agent 생성."""
+    """KIS_* 환경변수에서 인증 정보를 로드하여 Agent 생성."""
     load_env()
 
     from kis_agent import Agent
+    from kis_agent.core.constants import REAL_BASE_URL
 
     agent = Agent(
         app_key=os.environ.get("KIS_APP_KEY", ""),
-        app_secret=os.environ.get("KIS_APP_SECRET", os.environ.get("KIS_SECRET", "")),
+        app_secret=os.environ.get("KIS_APP_SECRET", ""),
         account_no=os.environ.get("KIS_ACCOUNT_NO", ""),
         account_code=os.environ.get("KIS_ACCOUNT_CODE", "01"),
-        base_url=os.environ.get(
-            "KIS_BASE_URL", "https://openapi.koreainvestment.com:9443"
-        ),
+        base_url=os.environ.get("KIS_BASE_URL", REAL_BASE_URL),
     )
 
     return agent

--- a/kis_agent/core/agent.py
+++ b/kis_agent/core/agent.py
@@ -25,6 +25,7 @@ from ..websocket.client import KisWebSocket
 from .base_exception_handler import BaseExceptionHandler, exception_handler
 from .client import KISClient
 from .config import KISConfig
+from .constants import REAL_BASE_URL
 from .method_discovery import MethodDiscoveryMixin
 from .rate_limiter import RateLimiter, get_global_rate_limiter
 from .technical_analysis import TechnicalAnalysisMixin
@@ -84,7 +85,7 @@ class Agent(TechnicalAnalysisMixin, MethodDiscoveryMixin, BaseExceptionHandler):
         app_secret: str,
         account_no: str,
         account_code: str,
-        base_url: str = "https://openapi.koreainvestment.com:9443",
+        base_url: str = REAL_BASE_URL,
         client: Optional[KISClient] = None,
         account_info: Optional[Dict] = None,
         enable_rate_limiter: bool = True,

--- a/kis_agent/core/auth.py
+++ b/kis_agent/core/auth.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Optional
 import requests
 from dotenv import load_dotenv
 
+from .constants import KIS_USER_AGENT_DEFAULT, MOCK_BASE_URL, REAL_BASE_URL
+
 # 모듈 레벨 로거 설정 (기본적으로 WARNING 이상만 출력)
 _logger = logging.getLogger(__name__)
 
@@ -29,15 +31,13 @@ _logger = logging.getLogger(__name__)
 # 구조: {app_key_prefix: {"access_token": str, "access_token_token_expired": str, "cached_at": datetime, "expired": datetime}}
 _token_cache: Dict[str, Dict[str, Any]] = {}
 
-# 환경설정 파일 로드 우선순위: 1) 현재 작업 디렉토리 .env, 2) PyKIS 패키지 루트 .env
-# 다른 프로젝트에서 PyKIS를 사용할 때는 해당 프로젝트의 .env를 우선 사용
+# .env 자동 로드: 현재 작업 디렉토리의 .env만 인식하며, 기존 환경변수는 덮어쓰지 않음.
+# (이전 버전은 패키지 부모 디렉토리(../../.env)까지 검색하고 override=True로 덮어썼으나,
+#  의도치 않은 환경 오염 가능성이 있어 v1.7.0에서 제거. 사용자가 임포트 위치와 무관하게
+#  자기 프로젝트의 .env를 사용하려면 dotenv를 직접 호출하거나 KISConfig에 매개변수 전달.)
 current_dir_env = os.path.join(os.getcwd(), ".env")
-pykis_root_env = os.path.join(os.path.dirname(__file__), "../../.env")
-
 if os.path.exists(current_dir_env):
-    load_dotenv(dotenv_path=current_dir_env, override=True)  # 현재 디렉토리 .env 우선
-elif os.path.exists(pykis_root_env):
-    load_dotenv(dotenv_path=pykis_root_env, override=True)  # PyKIS 루트 .env 대체
+    load_dotenv(dotenv_path=current_dir_env, override=False)
 
 
 def clearConsole() -> int:
@@ -91,17 +91,17 @@ def _get_token_path_for_app_key(app_key: str, base_path: str = token_tmp) -> str
     return os.path.join(dir_path, f"{base_name}_{key_hash}.json")
 
 
-# 환경 변수 기반 설정 로드 - STONKS 환경변수도 인식
+# 환경 변수 기반 설정 로드 — KIS_* prefix 전용
+# (Legacy 별칭 MY_APP/MY_SEC/KIS_SECRET/MY_ACCT_STOCK/MY_PROD/PROD_URL/VPS_URL/MY_AGENT 는
+#  v1.7.0에서 제거됨. 마이그레이션은 README 참조)
 _cfg = {
-    "my_app": os.getenv("KIS_APP_KEY") or os.getenv("MY_APP") or "",
-    "my_sec": os.getenv("KIS_APP_SECRET") or os.getenv("KIS_SECRET") or os.getenv("MY_SEC") or "",
-    "my_acct_stock": os.getenv("KIS_ACCOUNT_NO") or os.getenv("MY_ACCT_STOCK") or "",
-    "my_prod": os.getenv("KIS_ACCOUNT_CODE") or os.getenv("MY_PROD") or "01",
-    "prod": os.getenv("KIS_BASE_URL")
-    or os.getenv("PROD_URL")
-    or "https://openapi.koreainvestment.com:9443",
-    "vps": os.getenv("KIS_VPS_URL", "https://openapivts.koreainvestment.com:29443"),
-    "my_agent": os.getenv("KIS_USER_AGENT", "KIS_AGENT"),
+    "my_app": os.getenv("KIS_APP_KEY", ""),
+    "my_sec": os.getenv("KIS_APP_SECRET", ""),
+    "my_acct_stock": os.getenv("KIS_ACCOUNT_NO", ""),
+    "my_prod": os.getenv("KIS_ACCOUNT_CODE", "01"),
+    "prod": os.getenv("KIS_BASE_URL", REAL_BASE_URL),
+    "vps": os.getenv("KIS_VPS_URL", MOCK_BASE_URL),
+    "my_agent": os.getenv("KIS_USER_AGENT", KIS_USER_AGENT_DEFAULT),
 }
 
 # 이전 설정 파일 로드 로직 제거

--- a/kis_agent/core/client.py
+++ b/kis_agent/core/client.py
@@ -11,6 +11,8 @@ import requests
 
 from .auth import auth, getTREnv, read_token
 from .config import KISConfig
+from .constants import MOCK_BASE_URL, REAL_BASE_URL
+from .endpoints import API_ENDPOINTS
 from .rate_limiter import RateLimiter, get_global_rate_limiter
 
 # 로깅 설정
@@ -19,183 +21,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-API_ENDPOINTS = {
-    # === OAuth 인증 ===
-    "TOKEN": "/oauth2/tokenP",
-    "APPROVAL": "/oauth2/Approval",
-    "REVOKE": "/oauth2/revokeP",
-    "HASHKEY": "/uapi/hashkey",
-    # === 국내주식 시세 ===
-    "INQUIRE_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-price",  # 주식현재가 시세 (TR: FHKST01010100)
-    "INQUIRE_DAILY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-price",  # ELW 당일급변종목 (TR: FHPEW02870000)
-    "INQUIRE_TIME_ITEMCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice",  # 주식당일분봉조회(주식) (TR: FHKST03010200)
-    "INQUIRE_TIME_DAILYCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice",  # 일별분봉시세조회 (TR: FHKST03010230)
-    "INQUIRE_MEMBER": "/uapi/domestic-stock/v1/quotations/inquire-member",  # 주식현재가 회원사 (TR: FHKST01010600)
-    "INQUIRE_INVESTOR": "/uapi/domestic-stock/v1/quotations/inquire-investor",  # 주식현재가 투자자 (TR: FHKST01010900)
-    "INQUIRE_ASKING_PRICE_EXP_CCN": "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",  # 주식현재가 호가 예상체결 (TR: FHKST01010200)
-    "INQUIRE_CCNL": "/uapi/domestic-stock/v1/quotations/inquire-ccnl",  # 주식현재가 체결(최근30건) (TR: FHKST01010300)
-    "INQUIRE_DAILY_ITEMCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice",  # 국내주식기간별시세(일/주/월/년) (TR: FHKST03010100)
-    "INQUIRE_DAILY_INDEXCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice",  # 국내주식업종기간별시세(일/주/월/년) (TR: FHKUP03500100)
-    "INQUIRE_INDEX_DAILY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-daily-price",  # 국내업종 일자별지수 (TR: FHPUP02120000)
-    "INQUIRE_DAILY_OVERTIMEPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-overtimeprice",  # 주식현재가 시간외 일자별주가 (TR: FHPST02320000)
-    "INQUIRE_TIME_ITEMCONCLUSION": "/uapi/domestic-stock/v1/quotations/inquire-time-itemconclusion",  # 주식현재가 당일시간대별체결 (TR: FHPST01060000)
-    "INQUIRE_TIME_OVERTIMECONCLUSION": "/uapi/domestic-stock/v1/quotations/inquire-time-overtimeconclusion",  # 주식현재가 시간외 시간별체결 (TR: FHPST02310000)
-    "INQUIRE_OVERTIME_ASKING_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-overtime-asking-price",  # 국내주식 시간외호가 (TR: FHPST02300400)
-    "INQUIRE_OVERTIME_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-overtime-price",  # 국내주식 시간외현재가 (TR: FHPST02300000)
-    "INQUIRE_PRICE_2": "/uapi/domestic-stock/v1/quotations/inquire-price-2",  # 주식현재가 시세2 (TR: FHPST01010000)
-    "INQUIRE_ELW_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-elw-price",  # ELW 현재가 조회 (TR: FHKEW15010000)
-    "INQUIRE_INDEX_CATEGORY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-category-price",  # 업종별 지수 시세 (TR: FHKUP03500100)
-    "INQUIRE_INDEX_TICKPRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-tickprice",  # 지수 틱 시세 (TR: FHPUP02110100)
-    "INQUIRE_INDEX_TIMEPRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-timeprice",  # 지수 분/일봉 시세 (TR: FHKUP03500200)
-    "INQUIRE_TIME_INDEXCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-indexchartprice",  # 지수 분봉 차트 (TR: FHKUP03500100)
-    "DISPARITY": "/uapi/domestic-stock/v1/ranking/disparity",  # 국내주식 이격도 순위 (TR: FHPST01780000)
-    "DIVIDEND_RATE": "/uapi/domestic-stock/v1/ranking/dividend-rate",  # 국내주식 배당률 상위 (TR: HHKDB13470100)
-    "MARKET_TIME": "/uapi/domestic-stock/v1/quotations/market-time",  # 국내주식 시장영업시간 (TR: FHKST01550000)
-    "MARKET_VALUE": "/uapi/domestic-stock/v1/quotations/market-value",  # 국내주식 종목별 시가총액 (TR: FHKST70300200)
-    "PROFIT_ASSET_INDEX": "/uapi/domestic-stock/v1/quotations/profit-asset-index",  # 국내주식 자산/수익지수 (TR: FHKUP03500400)
-    "INTSTOCK_MULTPRICE": "/uapi/domestic-stock/v1/quotations/intstock-multprice",  # 국내주식 복수종목 현재가 (TR: FHKST662300C0)
-    # === 프로그램매매 ===
-    "PROGRAM_TRADE_BY_STOCK_DAILY": "/uapi/domestic-stock/v1/quotations/program-trade-by-stock-daily",  # 종목별 프로그램매매추이(일별) (TR: FHPPG04650200)
-    "PROGRAM_TRADE_BY_STOCK": "/uapi/domestic-stock/v1/quotations/program-trade-by-stock",  # 종목별프로그램매매추이(체결) (TR: FHPPG04650101)
-    "COMP_PROGRAM_TRADE_DAILY": "/uapi/domestic-stock/v1/quotations/comp-program-trade-daily",  # 프로그램매매 종합현황(일별) (TR: FHPPG04600000)
-    "COMP_PROGRAM_TRADE_TODAY": "/uapi/domestic-stock/v1/quotations/comp-program-trade-today",  # 프로그램매매 종합현황(시간) (TR: FHPPG04600100)
-    "INVESTOR_PROGRAM_TRADE_TODAY": "/uapi/domestic-stock/v1/quotations/investor-program-trade-today",  # 프로그램매매 투자자매매동향(당일) (TR: HHPPG046600C0)
-    # === 투자자별 ===
-    "INQUIRE_INVESTOR_TIME_BY_MARKET": "/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market",  # 시장별 투자자매매동향(시세) (TR: FHPTJ04030000)
-    "INQUIRE_INVESTOR_DAILY_BY_MARKET": "/uapi/domestic-stock/v1/quotations/inquire-investor-daily-by-market",  # 시장별 투자자매매동향(일별) (TR: FHPTJ04040000)
-    "INQUIRE_MEMBER_DAILY": "/uapi/domestic-stock/v1/quotations/inquire-member-daily",  # 주식현재가 회원사 종목매매동향 (TR: FHPST04540000)
-    "INVESTOR_TREND_ESTIMATE": "/uapi/domestic-stock/v1/quotations/investor-trend-estimate",  # 종목별 외인기관 추정가집계 (TR: HHPTJ04160200)
-    "INVESTOR_TRADE_BY_STOCK_DAILY": "/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily",  # 종목별 투자자매매동향(일별) (TR: FHPTJ04160001)
-    "FOREIGN_INSTITUTION_TOTAL": "/uapi/domestic-stock/v1/quotations/foreign-institution-total",  # 국내기관_외국인 매매종목가집계 (TR: FHPTJ04400000)
-    "FRGNMEM_PCHS_TREND": "/uapi/domestic-stock/v1/quotations/frgnmem-pchs-trend",  # 종목별 외국계 순매수추이 (TR: FHKST644400C0)
-    "FRGNMEM_TRADE_ESTIMATE": "/uapi/domestic-stock/v1/quotations/frgnmem-trade-estimate",  # 외국계 매매종목 가집계 (TR: FHKST644100C0)
-    "FRGNMEM_TRADE_TREND": "/uapi/domestic-stock/v1/quotations/frgnmem-trade-trend",  # 회원사 실시간 매매동향(틱) (TR: FHPST04320000)
-    # === 거래/주문 ===
-    "INQUIRE_BALANCE": "/uapi/domestic-stock/v1/trading/inquire-balance",  # 주식잔고조회 (TR: TTTC8434R)
-    "INQUIRE_PSBL_ORDER": "/uapi/domestic-stock/v1/trading/inquire-psbl-order",  # 매수가능조회 (TR: TTTC8908R)
-    "INQUIRE_PSBL_SELL": "/uapi/domestic-stock/v1/trading/inquire-psbl-sell",  # 매도가능수량조회 (TR: TTTC8408R)
-    "INQUIRE_DAILY_CCLD": "/uapi/domestic-stock/v1/trading/inquire-daily-ccld",  # 주식일별주문체결조회 (TR: TTTC8001R)
-    "INQUIRE_ACCOUNT_BALANCE": "/uapi/domestic-stock/v1/trading/inquire-account-balance",  # 투자계좌자산현황조회 (TR: CTRP6548R)
-    "INQUIRE_BALANCE_RLZ_PL": "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl",  # 주식잔고조회_실현손익 (TR: TTTC8494R)
-    "INQUIRE_PERIOD_PROFIT": "/uapi/domestic-stock/v1/trading/inquire-period-profit",  # 기간별손익일별합산조회 (TR: TTTC8708R)
-    "INQUIRE_PERIOD_TRADE_PROFIT": "/uapi/domestic-stock/v1/trading/inquire-period-trade-profit",  # 기간별매매손익현황조회 (TR: TTTC8715R)
-    "ORDER_CASH": "/uapi/domestic-stock/v1/trading/order-cash",  # 주식주문(현금) (TR: 매수-TTTC0012U/매도-TTTC0011U, Mock: VTTC0012U/VTTC0011U)
-    "ORDER_CREDIT": "/uapi/domestic-stock/v1/trading/order-credit",  # 주식주문(신용) (TR: 매수-TTTC0052U/매도-TTTC0051U, 실전만)
-    "INQUIRE_CREDIT_PSAMOUNT": "/uapi/domestic-stock/v1/trading/inquire-credit-psamount",  # 신용매수가능조회 (TR: TTTC8909R)
-    "INQUIRE_PSBL_RVSECNCL": "/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl",  # 주식정정취소가능주문조회 (TR: TTTC8036R)
-    "ORDER_RESV_CCNL": "/uapi/domestic-stock/v1/trading/order-resv-ccnl",  # 주식예약주문조회 (TR: CTSC0004R)
-    # === 시장정보/순위 ===
-    "VOLUME_RANK": "/uapi/domestic-stock/v1/quotations/volume-rank",  # 거래량순위 (TR: FHPST01710000)
-    "FLUCTUATION": "/uapi/domestic-stock/v1/ranking/fluctuation",  # 국내주식 등락률 순위 (TR: FHPST01700000)
-    "MARKET_CAP": "/uapi/domestic-stock/v1/ranking/market-cap",  # 국내주식 시가총액 상위 (TR: FHPST01740000)
-    "VOLUME_POWER": "/uapi/domestic-stock/v1/ranking/volume-power",  # 국내주식 체결강도 상위 (TR: FHPST01680000)
-    "AFTER_HOUR_BALANCE": "/uapi/domestic-stock/v1/ranking/after-hour-balance",  # 국내주식 시간외잔량 순위 (TR: FHPST01760000)
-    "SHORT_SALE": "/uapi/domestic-stock/v1/ranking/short-sale",  # 국내주식 공매도 상위종목 (TR: FHPST04820000)
-    "OVERTIME_FLUCTUATION": "/uapi/domestic-stock/v1/ranking/overtime-fluctuation",  # 국내주식 시간외등락율순위 (TR: FHPST02340000)
-    "OVERTIME_VOLUME": "/uapi/domestic-stock/v1/ranking/overtime-volume",  # 국내주식 시간외거래량순위 (TR: FHPST02350000)
-    # === 기타 시세정보 ===
-    "SEARCH_STOCK_INFO": "/uapi/domestic-stock/v1/quotations/search-stock-info",  # 주식기본조회 (TR: CTPF1002R)
-    "CHK_HOLIDAY": "/uapi/domestic-stock/v1/quotations/chk-holiday",  # 국내휴장일조회 (TR: CTCA0903R)
-    "PBAR_TRATIO": "/uapi/domestic-stock/v1/quotations/pbar-tratio",  # 국내주식 매물대/거래비중 (TR: FHPST01130000)
-    "CAPTURE_UPLOWPRICE": "/uapi/domestic-stock/v1/quotations/capture-uplowprice",  # 국내주식 상하한가 포착 (TR: FHKST130000C0)
-    "EXP_CLOSING_PRICE": "/uapi/domestic-stock/v1/quotations/exp-closing-price",  # 국내주식 장마감 예상체결가 (TR: FHKST117300C0)
-    "EXP_PRICE_TREND": "/uapi/domestic-stock/v1/quotations/exp-price-trend",  # 국내주식 예상체결가 추이 (TR: FHPST01810000)
-    "EXP_INDEX_TREND": "/uapi/domestic-stock/v1/quotations/exp-index-trend",  # 국내주식 예상체결지수 추이 (TR: FHPST01840000)
-    "INQUIRE_VI_STATUS": "/uapi/domestic-stock/v1/quotations/inquire-vi-status",  # 변동성완화장치(VI) 현황 (TR: FHPST01390000)
-    "INQUIRE_DAILY_TRADE_VOLUME": "/uapi/domestic-stock/v1/quotations/inquire-daily-trade-volume",  # 종목별일별매수매도체결량 (TR: FHKST03010800)
-    "NEWS_TITLE": "/uapi/domestic-stock/v1/quotations/news-title",  # 종합 시황/공시(제목) (TR: FHKST01011800)
-    "DAILY_CREDIT_BALANCE": "/uapi/domestic-stock/v1/quotations/daily-credit-balance",  # 국내주식 신용잔고 일별추이 (TR: FHPST04760000)
-    "DAILY_SHORT_SALE": "/uapi/domestic-stock/v1/quotations/daily-short-sale",  # 국내주식 공매도 일별추이 (TR: FHPST04830000)
-    "MKTFUNDS": "/uapi/domestic-stock/v1/quotations/mktfunds",  # 국내 증시자금 종합 (TR: FHKST649100C0)
-    # === 재무정보 ===
-    "INCOME_STATEMENT": "/uapi/domestic-stock/v1/finance/income-statement",  # 국내주식 손익계산서 (TR: FHKST66430200)
-    "BALANCE_SHEET": "/uapi/domestic-stock/v1/finance/balance-sheet",  # 국내주식 대차대조표 (TR: FHKST66430100)
-    "FINANCIAL_RATIO": "/uapi/domestic-stock/v1/finance/financial-ratio",  # 국내주식 재무비율 (TR: FHKST66430300)
-    "PROFIT_RATIO": "/uapi/domestic-stock/v1/finance/profit-ratio",  # 국내주식 수익성비율 (TR: FHKST66430400)
-    "STABILITY_RATIO": "/uapi/domestic-stock/v1/finance/stability-ratio",  # 국내주식 안정성비율 (TR: FHKST66430600)
-    "GROWTH_RATIO": "/uapi/domestic-stock/v1/finance/growth-ratio",  # 국내주식 성장성비율 (TR: FHKST66430800)
-    "ESTIMATE_PERFORM": "/uapi/domestic-stock/v1/quotations/estimate-perform",  # 국내주식 종목추정실적 (TR: HHKST668300C0)
-    "INVEST_OPINION": "/uapi/domestic-stock/v1/quotations/invest-opinion",  # 국내주식 종목투자의견 (TR: FHKST663300C0)
-    "INVEST_OPBYSEC": "/uapi/domestic-stock/v1/quotations/invest-opbysec",  # 국내주식 증권사별 투자의견 (TR: FHKST663400C0)
-    # === 해외주식 ===
-    "OVERSEAS_PRICE": "/uapi/overseas-price/v1/quotations/price",  # 해외주식 현재체결가 (TR: HHDFS00000300)
-    "OVERSEAS_PRICE_DETAIL": "/uapi/overseas-price/v1/quotations/price-detail",  # 해외주식 현재가상세 (TR: HHDFS76200200)
-    "OVERSEAS_DAILYPRICE": "/uapi/overseas-price/v1/quotations/dailyprice",  # 해외주식 기간별시세 (TR: HHDFS76240000)
-    "OVERSEAS_INQUIRE_ASKING_PRICE": "/uapi/overseas-price/v1/quotations/inquire-asking-price",  # 해외주식 현재가 10호가 (TR: HHDFS76200100)
-    "OVERSEAS_SEARCH_INFO": "/uapi/overseas-price/v1/quotations/search-info",  # 해외주식 상품기본정보 (TR: CTPF1702R)
-    "OVERSEAS_NEWS_TITLE": "/uapi/overseas-price/v1/quotations/news-title",  # 해외뉴스종합(제목) (TR: HHPSTH60100C1)
-    "OVERSEAS_INQUIRE_TIME_ITEMCHARTPRICE": "/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice",  # 해외주식분봉조회 (TR: HHDFS76950200)
-    "OVERSEAS_INQUIRE_DAILY_CHARTPRICE": "/uapi/overseas-price/v1/quotations/inquire-daily-chartprice",  # 해외주식 종목/지수/환율기간별시세 (TR: FHKST03030100)
-    # === 해외주식 거래 ===
-    "OVERSEAS_INQUIRE_BALANCE": "/uapi/overseas-stock/v1/trading/inquire-balance",  # 해외주식 잔고 (TR: TTTS3012R)
-    "OVERSEAS_INQUIRE_CCNL": "/uapi/overseas-stock/v1/trading/inquire-ccnl",  # 해외주식 주문체결내역 (TR: TTTS3035R)
-    "OVERSEAS_INQUIRE_PSAMOUNT": "/uapi/overseas-stock/v1/trading/inquire-psamount",  # 해외주식 매수가능금액조회 (TR: TTTS3007R)
-    # === 국내선물옵션 시세 (11개) ===
-    "FUTURES_DISPLAY_BOARD_CALLPUT": "/uapi/domestic-futureoption/v1/quotations/display-board-callput",  # 옵션 콜/풋 전광판 (TR: FHPIF05030100)
-    "FUTURES_DISPLAY_BOARD_FUTURES": "/uapi/domestic-futureoption/v1/quotations/display-board-futures",  # 선물 전광판 (TR: FHPIF05030200)
-    "FUTURES_DISPLAY_BOARD_OPTION_LIST": "/uapi/domestic-futureoption/v1/quotations/display-board-option-list",  # 옵션 목록 (TR: FHPIO056104C0)
-    "FUTURES_DISPLAY_BOARD_TOP": "/uapi/domestic-futureoption/v1/quotations/display-board-top",  # 상위 종목 (TR: FHPIF05030000)
-    "FUTURES_EXP_PRICE_TREND": "/uapi/domestic-futureoption/v1/quotations/exp-price-trend",  # 예상 가격 추이 (TR: FHPIF05110100)
-    "FUTURES_INQUIRE_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # 현재가 조회 (TR: FHMIF10000000)
-    "FUTURES_INQUIRE_ASKING_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-asking-price",  # 호가 조회 (TR: FHMIF10010000)
-    "FUTURES_INQUIRE_DAILY_FUOPCHARTPRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-daily-fuopchartprice",  # 일별 차트 (TR: FHKIF03020100)
-    "FUTURES_INQUIRE_TIME_FUOPCHARTPRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-time-fuopchartprice",  # 분봉 차트 (TR: FHKIF03020200)
-    "FUTURES_INQUIRE_CCNL_BSTIME": "/uapi/domestic-futureoption/v1/trading/inquire-ccnl-bstime",  # 시간대별 체결 (TR: CTFO5139R)
-    "FUTURES_INQUIRE_DAILY_AMOUNT_FEE": "/uapi/domestic-futureoption/v1/trading/inquire-daily-amount-fee",  # 일별 거래량/수수료 (TR: CTFO6119R)
-    # === 국내선물옵션 계좌/잔고 (6개) ===
-    "FUTURES_INQUIRE_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-balance",  # 잔고 조회 (TR: CTFO6118R/VTFO6118R)
-    "FUTURES_INQUIRE_BALANCE_SETTLEMENT_PL": "/uapi/domestic-futureoption/v1/trading/inquire-balance-settlement-pl",  # 청산손익 (TR: CTFO6117R)
-    "FUTURES_INQUIRE_BALANCE_VALUATION_PL": "/uapi/domestic-futureoption/v1/trading/inquire-balance-valuation-pl",  # 평가손익 (TR: CTFO6159R)
-    "FUTURES_INQUIRE_DEPOSIT": "/uapi/domestic-futureoption/v1/trading/inquire-deposit",  # 예수금 (TR: CTRP6550R)
-    "FUTURES_INQUIRE_NGT_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-ngt-balance",  # 야간 잔고 (TR: CTFN6118R)
-    "FUTURES_NGT_MARGIN_DETAIL": "/uapi/domestic-futureoption/v1/trading/ngt-margin-detail",  # 야간 증거금 (TR: CTFN7107R)
-    # === 국내선물옵션 주문/체결 (6개) ===
-    "FUTURES_INQUIRE_CCNL": "/uapi/domestic-futureoption/v1/trading/inquire-ccnl",  # 체결 내역 (TR: TTTO5201R/VTTO5201R)
-    "FUTURES_INQUIRE_NGT_CCNL": "/uapi/domestic-futureoption/v1/trading/inquire-ngt-ccnl",  # 야간 체결 (TR: STTN5201R)
-    "FUTURES_INQUIRE_PSBL_ORDER": "/uapi/domestic-futureoption/v1/trading/inquire-psbl-order",  # 주문 가능 수량 (TR: TTTO5105R/VTTO5105R)
-    "FUTURES_INQUIRE_PSBL_NGT_ORDER": "/uapi/domestic-futureoption/v1/trading/inquire-psbl-ngt-order",  # 야간 주문 가능 (TR: STTN5105R)
-    "FUTURES_ORDER": "/uapi/domestic-futureoption/v1/trading/order",  # 주문 (TR: TTTO1101U/TTTO1102U)
-    "FUTURES_ORDER_RVSECNCL": "/uapi/domestic-futureoption/v1/trading/order-rvsecncl",  # 정정/취소 (TR: TTTO1103U/TTTO1104U)
-    # === 레거시 (하위 호환성) ===
-    "FUTUREOPTION_INQUIRE_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # → FUTURES_INQUIRE_PRICE
-    "FUTUREOPTION_INQUIRE_ASKING_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-asking-price",  # → FUTURES_INQUIRE_ASKING_PRICE
-    "FUTUREOPTION_INQUIRE_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-balance",  # → FUTURES_INQUIRE_BALANCE
-    "INQUIRE_INDEX_PRICE": "/uapi/domestic-futureoption/v1/quotations/underlying-price",  # KOSPI 200 지수 (TR: FHMIF10100000)
-    "INQUIRE_FUTURES_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # → FUTURES_INQUIRE_PRICE
-    # === ETF/ETN ===
-    "ETF_INQUIRE_PRICE": "/uapi/etfetn/v1/quotations/inquire-price",  # ETF/ETN현재가 (TR: FHPST02400000)
-    "ETF_NAV_COMPARISON_TREND": "/uapi/etfetn/v1/quotations/nav-comparison-trend",  # NAV 비교추이(종목) (TR: FHPST02440000)
-    # === 채권 ===
-    "BOND_INQUIRE_PRICE": "/uapi/domestic-bond/v1/quotations/inquire-price",  # 장내채권현재가(시세) (TR: FHKBJ773400C0)
-    "BOND_INQUIRE_BALANCE": "/uapi/domestic-bond/v1/trading/inquire-balance",  # 장내채권 잔고조회 (TR: CTSC8407R)
-    # === 조건검색 ===
-    "CONDITIONED_STOCK": "/uapi/domestic-stock/v1/quotations/psearch-result",
-    # === 관심종목 ===
-    "INTEREST_GROUP_LIST": "/uapi/domestic-stock/v1/quotations/intstock-grouplist",  # 관심종목 그룹 조회
-    "INTEREST_STOCK_LIST": "/uapi/domestic-stock/v1/quotations/intstock-stocklist-by-group",  # 관심종목 그룹별 종목 조회
-    # === 해외선물옵션 시세 (8개) ===
-    "OVRS_FUTR_INQUIRE_PRICE": "/uapi/overseas-futureoption/v1/quotations/inquire-price",  # 해외선물종목현재가
-    "OVRS_FUTR_OPT_PRICE": "/uapi/overseas-futureoption/v1/quotations/opt-price",  # 해외옵션종목현재가
-    "OVRS_FUTR_MINUTE_CHART": "/uapi/overseas-futureoption/v1/quotations/inquire-time-futurechartprice",  # 해외선물 분봉조회
-    "OVRS_FUTR_DAILY_CCNL": "/uapi/overseas-futureoption/v1/quotations/daily-ccnl",  # 해외선물 체결추이(일간)
-    "OVRS_FUTR_ASKING_PRICE": "/uapi/overseas-futureoption/v1/quotations/inquire-asking-price",  # 해외선물 호가
-    "OVRS_FUTR_OPT_ASKING_PRICE": "/uapi/overseas-futureoption/v1/quotations/opt-asking-price",  # 해외옵션 호가
-    "OVRS_FUTR_CONTRACT_DETAIL": "/uapi/overseas-futureoption/v1/quotations/search-contract-detail",  # 해외선물 상품기본정보
-    "OVRS_FUTR_OPT_DETAIL": "/uapi/overseas-futureoption/v1/quotations/search-opt-detail",  # 해외옵션 상품기본정보
-    # === 해외선물옵션 계좌 (9개) ===
-    "OVRS_FUTR_BALANCE": "/uapi/overseas-futureoption/v1/trading/inquire-unpd",  # 미결제내역조회(잔고)
-    "OVRS_FUTR_DEPOSIT": "/uapi/overseas-futureoption/v1/trading/inquire-deposit",  # 예수금현황
-    "OVRS_FUTR_MARGIN": "/uapi/overseas-futureoption/v1/trading/margin-detail",  # 증거금상세
-    "OVRS_FUTR_PSAMOUNT": "/uapi/overseas-futureoption/v1/trading/inquire-psamount",  # 주문가능조회
-    "OVRS_FUTR_TODAY_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-ccld",  # 당일주문내역조회
-    "OVRS_FUTR_DAILY_ORDER": "/uapi/overseas-futureoption/v1/trading/inquire-daily-order",  # 일별 주문내역
-    "OVRS_FUTR_DAILY_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-daily-ccld",  # 일별 체결내역
-    "OVRS_FUTR_PERIOD_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-period-ccld",  # 기간계좌손익
-    "OVRS_FUTR_PERIOD_TRANS": "/uapi/overseas-futureoption/v1/trading/inquire-period-trans",  # 기간계좌거래내역
-    # === 해외선물옵션 주문 (2개) ===
-    "OVRS_FUTR_ORDER": "/uapi/overseas-futureoption/v1/trading/order",  # 해외선물옵션 주문
-    "OVRS_FUTR_ORDER_RVSECNCL": "/uapi/overseas-futureoption/v1/trading/order-rvsecncl",  # 정정취소주문
-}
 
 
 # 글로벌 rate limit 변수들 제거됨 - 인스턴스별 관리로 변경
@@ -245,6 +70,15 @@ class KISClient:
             svr = "prod"
         else:
             self.config = config
+
+        # config가 명시되지 않았으면 환경변수에서 자동 채움.
+        # KIS_* 환경변수가 충분치 않으면 None으로 둬서 기존 backward 경로(auth())가
+        # 자체적으로 처리하도록 둔다.
+        if self.config is None:
+            try:
+                self.config = KISConfig.from_env()
+            except ValueError:
+                self.config = None
         self.verbose = verbose
         self.token: Optional[str] = None
         self.token_expired: Optional[str] = None  # 토큰 만료 시간 저장
@@ -276,9 +110,8 @@ class KISClient:
         self._initialize_token()
 
         # is_real 속성 설정 (실전투자 여부 판단)
-        # 실전투자: https://openapi.koreainvestment.com:9443
-        # 모의투자: https://openapivts.koreainvestment.com:29443
-        self.is_real = "openapivts" not in getattr(self, "base_url", "")
+        # 실전 URL은 constants.REAL_BASE_URL, 모의 URL은 constants.MOCK_BASE_URL 참조.
+        self.is_real = MOCK_BASE_URL not in getattr(self, "base_url", "")
 
     def _initialize_token(self) -> None:
         """초기 토큰 발급 또는 기존 토큰 재사용 (Thread-Safe)"""
@@ -313,9 +146,7 @@ class KISClient:
                     # auth() 호출하여 헤더 설정 (토큰 재발급 없이 기존 토큰 로드)
                     if self.config is None:
                         auth(svr=self.svr)
-                        self.base_url = os.getenv(
-                            "KIS_BASE_URL", "https://openapi.koreainvestment.com:9443"
-                        )
+                        self.base_url = os.getenv("KIS_BASE_URL", REAL_BASE_URL)
                     else:
                         auth(config=self.config, svr=self.svr)
                         self.base_url = self.config.BASE_URL
@@ -329,9 +160,7 @@ class KISClient:
                                 "access_token_token_expired"
                             )
                             logger.info(f"토큰 발급 완료 (만료: {self.token_expired})")
-                        self.base_url = os.getenv(
-                            "KIS_BASE_URL", "https://openapi.koreainvestment.com:9443"
-                        )
+                        self.base_url = os.getenv("KIS_BASE_URL", REAL_BASE_URL)
                     else:
                         token_data = auth(config=self.config, svr=self.svr)
                         if token_data:
@@ -703,9 +532,9 @@ class KISClient:
 
         payload = {
             "grant_type": "client_credentials",
-            "appkey": self.config.app_key if self.config else os.getenv("KIS_APP_KEY"),
+            "appkey": self.config.app_key if self.config else os.getenv("KIS_APP_KEY", ""),
             "secretkey": (
-                self.config.app_secret if self.config else (os.getenv("KIS_APP_SECRET") or os.getenv("KIS_SECRET"))
+                self.config.app_secret if self.config else os.getenv("KIS_APP_SECRET", "")
             ),
         }
 

--- a/kis_agent/core/config.py
+++ b/kis_agent/core/config.py
@@ -1,13 +1,18 @@
+import os
 from dataclasses import dataclass
+
+from .constants import MOCK_BASE_URL, REAL_BASE_URL
 
 
 @dataclass
 class KISConfig:
-    """API 인증 및 계좌 정보를 관리하는 설정 클래스
+    """API 인증 및 계좌 정보를 관리하는 설정 클래스.
 
-    Note:
-        .env 파일 지원이 제거되었습니다.
-        API 키는 반드시 매개변수로 직정 전달해야 합니다.
+    환경변수 자동 로드를 지원한다.
+
+    - `KISConfig(app_key=..., ...)`로 매개변수 직접 전달 가능.
+    - `KISConfig.from_env()`로 환경변수에서 일괄 로드 가능 (KIS_* prefix만 인식).
+    - `.env` 파일은 `kis_agent.core.auth` 임포트 시 자동 로드된다 (override=False — 기존 환경변수 우선).
     """
 
     APP_KEY: str = ""
@@ -24,59 +29,65 @@ class KISConfig:
         account_no: str = None,
         account_code: str = None,
     ):
-        """
-        설정을 초기화합니다.
-
-        Args:
-            app_key (str): API 앱 키 (필수)
-            app_secret (str): API 앱 시크릿 (필수)
-            base_url (str): API 베이스 URL (기본값: 실전투자 URL)
-            account_no (str): 계좌번호 (필수)
-            account_code (str): 계좌 상품코드 (필수)
-        """
-        # 매개변수 설정
         self.APP_KEY = app_key or ""
         self.APP_SECRET = app_secret or ""
-        self.BASE_URL = base_url or "https://openapi.koreainvestment.com:9443"
+        self.BASE_URL = base_url or REAL_BASE_URL
         self.ACCOUNT_NO = account_no or ""
         self.ACCOUNT_CODE = account_code or ""
 
         self._validate()
 
+    @classmethod
+    def from_env(cls) -> "KISConfig":
+        """환경변수에서 KISConfig를 생성한다.
+
+        인식하는 환경변수 (KIS_* prefix 전용 — legacy MY_*/PROD_URL 등은 인식하지 않음):
+
+        - `KIS_APP_KEY` (필수)
+        - `KIS_APP_SECRET` (필수)
+        - `KIS_ACCOUNT_NO` (필수)
+        - `KIS_ACCOUNT_CODE` (선택, 기본 "01")
+        - `KIS_BASE_URL` (선택, 기본 실전투자 URL)
+
+        Raises:
+            ValueError: 필수 환경변수가 누락된 경우.
+        """
+        return cls(
+            app_key=os.environ.get("KIS_APP_KEY", ""),
+            app_secret=os.environ.get("KIS_APP_SECRET", ""),
+            base_url=os.environ.get("KIS_BASE_URL", REAL_BASE_URL),
+            account_no=os.environ.get("KIS_ACCOUNT_NO", ""),
+            account_code=os.environ.get("KIS_ACCOUNT_CODE", "01"),
+        )
+
     @property
     def account_stock(self) -> str:
-        """계좌 번호 반환"""
         return self.ACCOUNT_NO
 
     @property
     def account_product(self) -> str:
-        """계좌 상품 코드 반환"""
         return self.ACCOUNT_CODE
 
     @property
     def app_key(self) -> str:
-        """APP KEY 반환"""
         return self.APP_KEY
 
     @property
     def app_secret(self) -> str:
-        """APP SECRET 반환"""
         return self.APP_SECRET
 
     @property
     def account_no(self) -> str:
-        """계좌 번호 반환"""
         return self.ACCOUNT_NO
 
     @property
     def account_product_code(self) -> str:
-        """계좌 상품 코드 반환"""
         return self.ACCOUNT_CODE
 
     @property
     def is_real(self) -> bool:
-        """실투자 여부 (BASE_URL로 판단)"""
-        return "openapi.koreainvestment.com:9443" in self.BASE_URL
+        """실전투자 여부 (BASE_URL이 실전 URL과 일치하면 True)."""
+        return MOCK_BASE_URL not in self.BASE_URL
 
     def _validate(self) -> None:
         missing_fields = []
@@ -94,7 +105,8 @@ class KISConfig:
         if missing_fields:
             raise ValueError(
                 f"필수 설정 값이 누락되었습니다: {', '.join(missing_fields)}\n"
-                "필요한 모든 매개변수를 제공해주세요."
+                "필요한 모든 매개변수를 제공하거나 KIS_APP_KEY/KIS_APP_SECRET/"
+                "KIS_ACCOUNT_NO 환경변수를 설정한 뒤 KISConfig.from_env()를 사용하세요."
             )
 
 

--- a/kis_agent/core/constants.py
+++ b/kis_agent/core/constants.py
@@ -1,0 +1,38 @@
+"""kis-agent 전역 상수 정의 모듈.
+
+URL/엔드포인트/계좌 상품코드 등 코드 곳곳에 산재했던 매직 리터럴을
+단일 진실의 출처(single source of truth)로 모은다.
+
+다른 모듈에서는 항상 이 모듈을 import해서 참조한다 — 문자열 리터럴 중복 금지.
+"""
+
+from enum import Enum
+
+REAL_BASE_URL = "https://openapi.koreainvestment.com:9443"
+MOCK_BASE_URL = "https://openapivts.koreainvestment.com:29443"
+
+WS_REAL_URL = "ws://ops.koreainvestment.com:21000"
+WS_MOCK_URL = "ws://ops.koreainvestment.com:31000"
+
+KIS_USER_AGENT_DEFAULT = "KIS_AGENT"
+
+
+class AccountProductCode(str, Enum):
+    """계좌 상품코드 (KIS 공식).
+
+    Python 3.8 호환을 위해 `StrEnum` 대신 `str, Enum` 패턴 사용
+    (선례: `kis_agent.message_schema.ResponseStatus`).
+    """
+
+    STOCK = "01"
+    FUTURES = "03"  # 선물옵션 및 해외선물옵션 공통 코드
+
+
+__all__ = [
+    "REAL_BASE_URL",
+    "MOCK_BASE_URL",
+    "WS_REAL_URL",
+    "WS_MOCK_URL",
+    "KIS_USER_AGENT_DEFAULT",
+    "AccountProductCode",
+]

--- a/kis_agent/core/endpoints.py
+++ b/kis_agent/core/endpoints.py
@@ -1,0 +1,189 @@
+"""KIS OpenAPI REST 엔드포인트 정의.
+
+원래 ``kis_agent/core/client.py`` 상단에 있던 ``API_ENDPOINTS`` dict를
+독립 모듈로 분리한 것. 엔드포인트가 많고 도메인별로 다층이라 별도 모듈로
+관리하는 편이 가독성·유지보수성에 유리하다.
+
+엔트리는 단순 문자열 매핑이지만 일부 키는 deprecated alias이며 주석에
+명시되어 있다.
+"""
+
+API_ENDPOINTS = {
+    # === OAuth 인증 ===
+    "TOKEN": "/oauth2/tokenP",
+    "APPROVAL": "/oauth2/Approval",
+    "REVOKE": "/oauth2/revokeP",
+    "HASHKEY": "/uapi/hashkey",
+    # === 국내주식 시세 ===
+    "INQUIRE_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-price",  # 주식현재가 시세 (TR: FHKST01010100)
+    "INQUIRE_DAILY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-price",  # ELW 당일급변종목 (TR: FHPEW02870000)
+    "INQUIRE_TIME_ITEMCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice",  # 주식당일분봉조회(주식) (TR: FHKST03010200)
+    "INQUIRE_TIME_DAILYCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice",  # 일별분봉시세조회 (TR: FHKST03010230)
+    "INQUIRE_MEMBER": "/uapi/domestic-stock/v1/quotations/inquire-member",  # 주식현재가 회원사 (TR: FHKST01010600)
+    "INQUIRE_INVESTOR": "/uapi/domestic-stock/v1/quotations/inquire-investor",  # 주식현재가 투자자 (TR: FHKST01010900)
+    "INQUIRE_ASKING_PRICE_EXP_CCN": "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",  # 주식현재가 호가 예상체결 (TR: FHKST01010200)
+    "INQUIRE_CCNL": "/uapi/domestic-stock/v1/quotations/inquire-ccnl",  # 주식현재가 체결(최근30건) (TR: FHKST01010300)
+    "INQUIRE_DAILY_ITEMCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice",  # 국내주식기간별시세(일/주/월/년) (TR: FHKST03010100)
+    "INQUIRE_DAILY_INDEXCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice",  # 국내주식업종기간별시세(일/주/월/년) (TR: FHKUP03500100)
+    "INQUIRE_INDEX_DAILY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-daily-price",  # 국내업종 일자별지수 (TR: FHPUP02120000)
+    "INQUIRE_DAILY_OVERTIMEPRICE": "/uapi/domestic-stock/v1/quotations/inquire-daily-overtimeprice",  # 주식현재가 시간외 일자별주가 (TR: FHPST02320000)
+    "INQUIRE_TIME_ITEMCONCLUSION": "/uapi/domestic-stock/v1/quotations/inquire-time-itemconclusion",  # 주식현재가 당일시간대별체결 (TR: FHPST01060000)
+    "INQUIRE_TIME_OVERTIMECONCLUSION": "/uapi/domestic-stock/v1/quotations/inquire-time-overtimeconclusion",  # 주식현재가 시간외 시간별체결 (TR: FHPST02310000)
+    "INQUIRE_OVERTIME_ASKING_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-overtime-asking-price",  # 국내주식 시간외호가 (TR: FHPST02300400)
+    "INQUIRE_OVERTIME_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-overtime-price",  # 국내주식 시간외현재가 (TR: FHPST02300000)
+    "INQUIRE_PRICE_2": "/uapi/domestic-stock/v1/quotations/inquire-price-2",  # 주식현재가 시세2 (TR: FHPST01010000)
+    "INQUIRE_ELW_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-elw-price",  # ELW 현재가 조회 (TR: FHKEW15010000)
+    "INQUIRE_INDEX_CATEGORY_PRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-category-price",  # 업종별 지수 시세 (TR: FHKUP03500100)
+    "INQUIRE_INDEX_TICKPRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-tickprice",  # 지수 틱 시세 (TR: FHPUP02110100)
+    "INQUIRE_INDEX_TIMEPRICE": "/uapi/domestic-stock/v1/quotations/inquire-index-timeprice",  # 지수 분/일봉 시세 (TR: FHKUP03500200)
+    "INQUIRE_TIME_INDEXCHARTPRICE": "/uapi/domestic-stock/v1/quotations/inquire-time-indexchartprice",  # 지수 분봉 차트 (TR: FHKUP03500100)
+    "DISPARITY": "/uapi/domestic-stock/v1/ranking/disparity",  # 국내주식 이격도 순위 (TR: FHPST01780000)
+    "DIVIDEND_RATE": "/uapi/domestic-stock/v1/ranking/dividend-rate",  # 국내주식 배당률 상위 (TR: HHKDB13470100)
+    "MARKET_TIME": "/uapi/domestic-stock/v1/quotations/market-time",  # 국내주식 시장영업시간 (TR: FHKST01550000)
+    "MARKET_VALUE": "/uapi/domestic-stock/v1/quotations/market-value",  # 국내주식 종목별 시가총액 (TR: FHKST70300200)
+    "PROFIT_ASSET_INDEX": "/uapi/domestic-stock/v1/quotations/profit-asset-index",  # 국내주식 자산/수익지수 (TR: FHKUP03500400)
+    "INTSTOCK_MULTPRICE": "/uapi/domestic-stock/v1/quotations/intstock-multprice",  # 국내주식 복수종목 현재가 (TR: FHKST662300C0)
+    # === 프로그램매매 ===
+    "PROGRAM_TRADE_BY_STOCK_DAILY": "/uapi/domestic-stock/v1/quotations/program-trade-by-stock-daily",  # 종목별 프로그램매매추이(일별) (TR: FHPPG04650200)
+    "PROGRAM_TRADE_BY_STOCK": "/uapi/domestic-stock/v1/quotations/program-trade-by-stock",  # 종목별프로그램매매추이(체결) (TR: FHPPG04650101)
+    "COMP_PROGRAM_TRADE_DAILY": "/uapi/domestic-stock/v1/quotations/comp-program-trade-daily",  # 프로그램매매 종합현황(일별) (TR: FHPPG04600000)
+    "COMP_PROGRAM_TRADE_TODAY": "/uapi/domestic-stock/v1/quotations/comp-program-trade-today",  # 프로그램매매 종합현황(시간) (TR: FHPPG04600100)
+    "INVESTOR_PROGRAM_TRADE_TODAY": "/uapi/domestic-stock/v1/quotations/investor-program-trade-today",  # 프로그램매매 투자자매매동향(당일) (TR: HHPPG046600C0)
+    # === 투자자별 ===
+    "INQUIRE_INVESTOR_TIME_BY_MARKET": "/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market",  # 시장별 투자자매매동향(시세) (TR: FHPTJ04030000)
+    "INQUIRE_INVESTOR_DAILY_BY_MARKET": "/uapi/domestic-stock/v1/quotations/inquire-investor-daily-by-market",  # 시장별 투자자매매동향(일별) (TR: FHPTJ04040000)
+    "INQUIRE_MEMBER_DAILY": "/uapi/domestic-stock/v1/quotations/inquire-member-daily",  # 주식현재가 회원사 종목매매동향 (TR: FHPST04540000)
+    "INVESTOR_TREND_ESTIMATE": "/uapi/domestic-stock/v1/quotations/investor-trend-estimate",  # 종목별 외인기관 추정가집계 (TR: HHPTJ04160200)
+    "INVESTOR_TRADE_BY_STOCK_DAILY": "/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily",  # 종목별 투자자매매동향(일별) (TR: FHPTJ04160001)
+    "FOREIGN_INSTITUTION_TOTAL": "/uapi/domestic-stock/v1/quotations/foreign-institution-total",  # 국내기관_외국인 매매종목가집계 (TR: FHPTJ04400000)
+    "FRGNMEM_PCHS_TREND": "/uapi/domestic-stock/v1/quotations/frgnmem-pchs-trend",  # 종목별 외국계 순매수추이 (TR: FHKST644400C0)
+    "FRGNMEM_TRADE_ESTIMATE": "/uapi/domestic-stock/v1/quotations/frgnmem-trade-estimate",  # 외국계 매매종목 가집계 (TR: FHKST644100C0)
+    "FRGNMEM_TRADE_TREND": "/uapi/domestic-stock/v1/quotations/frgnmem-trade-trend",  # 회원사 실시간 매매동향(틱) (TR: FHPST04320000)
+    # === 거래/주문 ===
+    "INQUIRE_BALANCE": "/uapi/domestic-stock/v1/trading/inquire-balance",  # 주식잔고조회 (TR: TTTC8434R)
+    "INQUIRE_PSBL_ORDER": "/uapi/domestic-stock/v1/trading/inquire-psbl-order",  # 매수가능조회 (TR: TTTC8908R)
+    "INQUIRE_PSBL_SELL": "/uapi/domestic-stock/v1/trading/inquire-psbl-sell",  # 매도가능수량조회 (TR: TTTC8408R)
+    "INQUIRE_DAILY_CCLD": "/uapi/domestic-stock/v1/trading/inquire-daily-ccld",  # 주식일별주문체결조회 (TR: TTTC8001R)
+    "INQUIRE_ACCOUNT_BALANCE": "/uapi/domestic-stock/v1/trading/inquire-account-balance",  # 투자계좌자산현황조회 (TR: CTRP6548R)
+    "INQUIRE_BALANCE_RLZ_PL": "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl",  # 주식잔고조회_실현손익 (TR: TTTC8494R)
+    "INQUIRE_PERIOD_PROFIT": "/uapi/domestic-stock/v1/trading/inquire-period-profit",  # 기간별손익일별합산조회 (TR: TTTC8708R)
+    "INQUIRE_PERIOD_TRADE_PROFIT": "/uapi/domestic-stock/v1/trading/inquire-period-trade-profit",  # 기간별매매손익현황조회 (TR: TTTC8715R)
+    "ORDER_CASH": "/uapi/domestic-stock/v1/trading/order-cash",  # 주식주문(현금) (TR: 매수-TTTC0012U/매도-TTTC0011U, Mock: VTTC0012U/VTTC0011U)
+    "ORDER_CREDIT": "/uapi/domestic-stock/v1/trading/order-credit",  # 주식주문(신용) (TR: 매수-TTTC0052U/매도-TTTC0051U, 실전만)
+    "INQUIRE_CREDIT_PSAMOUNT": "/uapi/domestic-stock/v1/trading/inquire-credit-psamount",  # 신용매수가능조회 (TR: TTTC8909R)
+    "INQUIRE_PSBL_RVSECNCL": "/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl",  # 주식정정취소가능주문조회 (TR: TTTC8036R)
+    "ORDER_RESV_CCNL": "/uapi/domestic-stock/v1/trading/order-resv-ccnl",  # 주식예약주문조회 (TR: CTSC0004R)
+    # === 시장정보/순위 ===
+    "VOLUME_RANK": "/uapi/domestic-stock/v1/quotations/volume-rank",  # 거래량순위 (TR: FHPST01710000)
+    "FLUCTUATION": "/uapi/domestic-stock/v1/ranking/fluctuation",  # 국내주식 등락률 순위 (TR: FHPST01700000)
+    "MARKET_CAP": "/uapi/domestic-stock/v1/ranking/market-cap",  # 국내주식 시가총액 상위 (TR: FHPST01740000)
+    "VOLUME_POWER": "/uapi/domestic-stock/v1/ranking/volume-power",  # 국내주식 체결강도 상위 (TR: FHPST01680000)
+    "AFTER_HOUR_BALANCE": "/uapi/domestic-stock/v1/ranking/after-hour-balance",  # 국내주식 시간외잔량 순위 (TR: FHPST01760000)
+    "SHORT_SALE": "/uapi/domestic-stock/v1/ranking/short-sale",  # 국내주식 공매도 상위종목 (TR: FHPST04820000)
+    "OVERTIME_FLUCTUATION": "/uapi/domestic-stock/v1/ranking/overtime-fluctuation",  # 국내주식 시간외등락율순위 (TR: FHPST02340000)
+    "OVERTIME_VOLUME": "/uapi/domestic-stock/v1/ranking/overtime-volume",  # 국내주식 시간외거래량순위 (TR: FHPST02350000)
+    # === 기타 시세정보 ===
+    "SEARCH_STOCK_INFO": "/uapi/domestic-stock/v1/quotations/search-stock-info",  # 주식기본조회 (TR: CTPF1002R)
+    "CHK_HOLIDAY": "/uapi/domestic-stock/v1/quotations/chk-holiday",  # 국내휴장일조회 (TR: CTCA0903R)
+    "PBAR_TRATIO": "/uapi/domestic-stock/v1/quotations/pbar-tratio",  # 국내주식 매물대/거래비중 (TR: FHPST01130000)
+    "CAPTURE_UPLOWPRICE": "/uapi/domestic-stock/v1/quotations/capture-uplowprice",  # 국내주식 상하한가 포착 (TR: FHKST130000C0)
+    "EXP_CLOSING_PRICE": "/uapi/domestic-stock/v1/quotations/exp-closing-price",  # 국내주식 장마감 예상체결가 (TR: FHKST117300C0)
+    "EXP_PRICE_TREND": "/uapi/domestic-stock/v1/quotations/exp-price-trend",  # 국내주식 예상체결가 추이 (TR: FHPST01810000)
+    "EXP_INDEX_TREND": "/uapi/domestic-stock/v1/quotations/exp-index-trend",  # 국내주식 예상체결지수 추이 (TR: FHPST01840000)
+    "INQUIRE_VI_STATUS": "/uapi/domestic-stock/v1/quotations/inquire-vi-status",  # 변동성완화장치(VI) 현황 (TR: FHPST01390000)
+    "INQUIRE_DAILY_TRADE_VOLUME": "/uapi/domestic-stock/v1/quotations/inquire-daily-trade-volume",  # 종목별일별매수매도체결량 (TR: FHKST03010800)
+    "NEWS_TITLE": "/uapi/domestic-stock/v1/quotations/news-title",  # 종합 시황/공시(제목) (TR: FHKST01011800)
+    "DAILY_CREDIT_BALANCE": "/uapi/domestic-stock/v1/quotations/daily-credit-balance",  # 국내주식 신용잔고 일별추이 (TR: FHPST04760000)
+    "DAILY_SHORT_SALE": "/uapi/domestic-stock/v1/quotations/daily-short-sale",  # 국내주식 공매도 일별추이 (TR: FHPST04830000)
+    "MKTFUNDS": "/uapi/domestic-stock/v1/quotations/mktfunds",  # 국내 증시자금 종합 (TR: FHKST649100C0)
+    # === 재무정보 ===
+    "INCOME_STATEMENT": "/uapi/domestic-stock/v1/finance/income-statement",  # 국내주식 손익계산서 (TR: FHKST66430200)
+    "BALANCE_SHEET": "/uapi/domestic-stock/v1/finance/balance-sheet",  # 국내주식 대차대조표 (TR: FHKST66430100)
+    "FINANCIAL_RATIO": "/uapi/domestic-stock/v1/finance/financial-ratio",  # 국내주식 재무비율 (TR: FHKST66430300)
+    "PROFIT_RATIO": "/uapi/domestic-stock/v1/finance/profit-ratio",  # 국내주식 수익성비율 (TR: FHKST66430400)
+    "STABILITY_RATIO": "/uapi/domestic-stock/v1/finance/stability-ratio",  # 국내주식 안정성비율 (TR: FHKST66430600)
+    "GROWTH_RATIO": "/uapi/domestic-stock/v1/finance/growth-ratio",  # 국내주식 성장성비율 (TR: FHKST66430800)
+    "ESTIMATE_PERFORM": "/uapi/domestic-stock/v1/quotations/estimate-perform",  # 국내주식 종목추정실적 (TR: HHKST668300C0)
+    "INVEST_OPINION": "/uapi/domestic-stock/v1/quotations/invest-opinion",  # 국내주식 종목투자의견 (TR: FHKST663300C0)
+    "INVEST_OPBYSEC": "/uapi/domestic-stock/v1/quotations/invest-opbysec",  # 국내주식 증권사별 투자의견 (TR: FHKST663400C0)
+    # === 해외주식 ===
+    "OVERSEAS_PRICE": "/uapi/overseas-price/v1/quotations/price",  # 해외주식 현재체결가 (TR: HHDFS00000300)
+    "OVERSEAS_PRICE_DETAIL": "/uapi/overseas-price/v1/quotations/price-detail",  # 해외주식 현재가상세 (TR: HHDFS76200200)
+    "OVERSEAS_DAILYPRICE": "/uapi/overseas-price/v1/quotations/dailyprice",  # 해외주식 기간별시세 (TR: HHDFS76240000)
+    "OVERSEAS_INQUIRE_ASKING_PRICE": "/uapi/overseas-price/v1/quotations/inquire-asking-price",  # 해외주식 현재가 10호가 (TR: HHDFS76200100)
+    "OVERSEAS_SEARCH_INFO": "/uapi/overseas-price/v1/quotations/search-info",  # 해외주식 상품기본정보 (TR: CTPF1702R)
+    "OVERSEAS_NEWS_TITLE": "/uapi/overseas-price/v1/quotations/news-title",  # 해외뉴스종합(제목) (TR: HHPSTH60100C1)
+    "OVERSEAS_INQUIRE_TIME_ITEMCHARTPRICE": "/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice",  # 해외주식분봉조회 (TR: HHDFS76950200)
+    "OVERSEAS_INQUIRE_DAILY_CHARTPRICE": "/uapi/overseas-price/v1/quotations/inquire-daily-chartprice",  # 해외주식 종목/지수/환율기간별시세 (TR: FHKST03030100)
+    # === 해외주식 거래 ===
+    "OVERSEAS_INQUIRE_BALANCE": "/uapi/overseas-stock/v1/trading/inquire-balance",  # 해외주식 잔고 (TR: TTTS3012R)
+    "OVERSEAS_INQUIRE_CCNL": "/uapi/overseas-stock/v1/trading/inquire-ccnl",  # 해외주식 주문체결내역 (TR: TTTS3035R)
+    "OVERSEAS_INQUIRE_PSAMOUNT": "/uapi/overseas-stock/v1/trading/inquire-psamount",  # 해외주식 매수가능금액조회 (TR: TTTS3007R)
+    # === 국내선물옵션 시세 (11개) ===
+    "FUTURES_DISPLAY_BOARD_CALLPUT": "/uapi/domestic-futureoption/v1/quotations/display-board-callput",  # 옵션 콜/풋 전광판 (TR: FHPIF05030100)
+    "FUTURES_DISPLAY_BOARD_FUTURES": "/uapi/domestic-futureoption/v1/quotations/display-board-futures",  # 선물 전광판 (TR: FHPIF05030200)
+    "FUTURES_DISPLAY_BOARD_OPTION_LIST": "/uapi/domestic-futureoption/v1/quotations/display-board-option-list",  # 옵션 목록 (TR: FHPIO056104C0)
+    "FUTURES_DISPLAY_BOARD_TOP": "/uapi/domestic-futureoption/v1/quotations/display-board-top",  # 상위 종목 (TR: FHPIF05030000)
+    "FUTURES_EXP_PRICE_TREND": "/uapi/domestic-futureoption/v1/quotations/exp-price-trend",  # 예상 가격 추이 (TR: FHPIF05110100)
+    "FUTURES_INQUIRE_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # 현재가 조회 (TR: FHMIF10000000)
+    "FUTURES_INQUIRE_ASKING_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-asking-price",  # 호가 조회 (TR: FHMIF10010000)
+    "FUTURES_INQUIRE_DAILY_FUOPCHARTPRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-daily-fuopchartprice",  # 일별 차트 (TR: FHKIF03020100)
+    "FUTURES_INQUIRE_TIME_FUOPCHARTPRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-time-fuopchartprice",  # 분봉 차트 (TR: FHKIF03020200)
+    "FUTURES_INQUIRE_CCNL_BSTIME": "/uapi/domestic-futureoption/v1/trading/inquire-ccnl-bstime",  # 시간대별 체결 (TR: CTFO5139R)
+    "FUTURES_INQUIRE_DAILY_AMOUNT_FEE": "/uapi/domestic-futureoption/v1/trading/inquire-daily-amount-fee",  # 일별 거래량/수수료 (TR: CTFO6119R)
+    # === 국내선물옵션 계좌/잔고 (6개) ===
+    "FUTURES_INQUIRE_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-balance",  # 잔고 조회 (TR: CTFO6118R/VTFO6118R)
+    "FUTURES_INQUIRE_BALANCE_SETTLEMENT_PL": "/uapi/domestic-futureoption/v1/trading/inquire-balance-settlement-pl",  # 청산손익 (TR: CTFO6117R)
+    "FUTURES_INQUIRE_BALANCE_VALUATION_PL": "/uapi/domestic-futureoption/v1/trading/inquire-balance-valuation-pl",  # 평가손익 (TR: CTFO6159R)
+    "FUTURES_INQUIRE_DEPOSIT": "/uapi/domestic-futureoption/v1/trading/inquire-deposit",  # 예수금 (TR: CTRP6550R)
+    "FUTURES_INQUIRE_NGT_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-ngt-balance",  # 야간 잔고 (TR: CTFN6118R)
+    "FUTURES_NGT_MARGIN_DETAIL": "/uapi/domestic-futureoption/v1/trading/ngt-margin-detail",  # 야간 증거금 (TR: CTFN7107R)
+    # === 국내선물옵션 주문/체결 (6개) ===
+    "FUTURES_INQUIRE_CCNL": "/uapi/domestic-futureoption/v1/trading/inquire-ccnl",  # 체결 내역 (TR: TTTO5201R/VTTO5201R)
+    "FUTURES_INQUIRE_NGT_CCNL": "/uapi/domestic-futureoption/v1/trading/inquire-ngt-ccnl",  # 야간 체결 (TR: STTN5201R)
+    "FUTURES_INQUIRE_PSBL_ORDER": "/uapi/domestic-futureoption/v1/trading/inquire-psbl-order",  # 주문 가능 수량 (TR: TTTO5105R/VTTO5105R)
+    "FUTURES_INQUIRE_PSBL_NGT_ORDER": "/uapi/domestic-futureoption/v1/trading/inquire-psbl-ngt-order",  # 야간 주문 가능 (TR: STTN5105R)
+    "FUTURES_ORDER": "/uapi/domestic-futureoption/v1/trading/order",  # 주문 (TR: TTTO1101U/TTTO1102U)
+    "FUTURES_ORDER_RVSECNCL": "/uapi/domestic-futureoption/v1/trading/order-rvsecncl",  # 정정/취소 (TR: TTTO1103U/TTTO1104U)
+    # === 레거시 (하위 호환성) ===
+    "FUTUREOPTION_INQUIRE_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # → FUTURES_INQUIRE_PRICE
+    "FUTUREOPTION_INQUIRE_ASKING_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-asking-price",  # → FUTURES_INQUIRE_ASKING_PRICE
+    "FUTUREOPTION_INQUIRE_BALANCE": "/uapi/domestic-futureoption/v1/trading/inquire-balance",  # → FUTURES_INQUIRE_BALANCE
+    "INQUIRE_INDEX_PRICE": "/uapi/domestic-futureoption/v1/quotations/underlying-price",  # KOSPI 200 지수 (TR: FHMIF10100000)
+    "INQUIRE_FUTURES_PRICE": "/uapi/domestic-futureoption/v1/quotations/inquire-price",  # → FUTURES_INQUIRE_PRICE
+    # === ETF/ETN ===
+    "ETF_INQUIRE_PRICE": "/uapi/etfetn/v1/quotations/inquire-price",  # ETF/ETN현재가 (TR: FHPST02400000)
+    "ETF_NAV_COMPARISON_TREND": "/uapi/etfetn/v1/quotations/nav-comparison-trend",  # NAV 비교추이(종목) (TR: FHPST02440000)
+    # === 채권 ===
+    "BOND_INQUIRE_PRICE": "/uapi/domestic-bond/v1/quotations/inquire-price",  # 장내채권현재가(시세) (TR: FHKBJ773400C0)
+    "BOND_INQUIRE_BALANCE": "/uapi/domestic-bond/v1/trading/inquire-balance",  # 장내채권 잔고조회 (TR: CTSC8407R)
+    # === 조건검색 ===
+    "CONDITIONED_STOCK": "/uapi/domestic-stock/v1/quotations/psearch-result",
+    # === 관심종목 ===
+    "INTEREST_GROUP_LIST": "/uapi/domestic-stock/v1/quotations/intstock-grouplist",  # 관심종목 그룹 조회
+    "INTEREST_STOCK_LIST": "/uapi/domestic-stock/v1/quotations/intstock-stocklist-by-group",  # 관심종목 그룹별 종목 조회
+    # === 해외선물옵션 시세 (8개) ===
+    "OVRS_FUTR_INQUIRE_PRICE": "/uapi/overseas-futureoption/v1/quotations/inquire-price",  # 해외선물종목현재가
+    "OVRS_FUTR_OPT_PRICE": "/uapi/overseas-futureoption/v1/quotations/opt-price",  # 해외옵션종목현재가
+    "OVRS_FUTR_MINUTE_CHART": "/uapi/overseas-futureoption/v1/quotations/inquire-time-futurechartprice",  # 해외선물 분봉조회
+    "OVRS_FUTR_DAILY_CCNL": "/uapi/overseas-futureoption/v1/quotations/daily-ccnl",  # 해외선물 체결추이(일간)
+    "OVRS_FUTR_ASKING_PRICE": "/uapi/overseas-futureoption/v1/quotations/inquire-asking-price",  # 해외선물 호가
+    "OVRS_FUTR_OPT_ASKING_PRICE": "/uapi/overseas-futureoption/v1/quotations/opt-asking-price",  # 해외옵션 호가
+    "OVRS_FUTR_CONTRACT_DETAIL": "/uapi/overseas-futureoption/v1/quotations/search-contract-detail",  # 해외선물 상품기본정보
+    "OVRS_FUTR_OPT_DETAIL": "/uapi/overseas-futureoption/v1/quotations/search-opt-detail",  # 해외옵션 상품기본정보
+    # === 해외선물옵션 계좌 (9개) ===
+    "OVRS_FUTR_BALANCE": "/uapi/overseas-futureoption/v1/trading/inquire-unpd",  # 미결제내역조회(잔고)
+    "OVRS_FUTR_DEPOSIT": "/uapi/overseas-futureoption/v1/trading/inquire-deposit",  # 예수금현황
+    "OVRS_FUTR_MARGIN": "/uapi/overseas-futureoption/v1/trading/margin-detail",  # 증거금상세
+    "OVRS_FUTR_PSAMOUNT": "/uapi/overseas-futureoption/v1/trading/inquire-psamount",  # 주문가능조회
+    "OVRS_FUTR_TODAY_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-ccld",  # 당일주문내역조회
+    "OVRS_FUTR_DAILY_ORDER": "/uapi/overseas-futureoption/v1/trading/inquire-daily-order",  # 일별 주문내역
+    "OVRS_FUTR_DAILY_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-daily-ccld",  # 일별 체결내역
+    "OVRS_FUTR_PERIOD_CCLD": "/uapi/overseas-futureoption/v1/trading/inquire-period-ccld",  # 기간계좌손익
+    "OVRS_FUTR_PERIOD_TRANS": "/uapi/overseas-futureoption/v1/trading/inquire-period-trans",  # 기간계좌거래내역
+    # === 해외선물옵션 주문 (2개) ===
+    "OVRS_FUTR_ORDER": "/uapi/overseas-futureoption/v1/trading/order",  # 해외선물옵션 주문
+    "OVRS_FUTR_ORDER_RVSECNCL": "/uapi/overseas-futureoption/v1/trading/order-rvsecncl",  # 정정취소주문
+}
+
+__all__ = ["API_ENDPOINTS"]

--- a/kis_agent/websocket/client.py
+++ b/kis_agent/websocket/client.py
@@ -17,6 +17,7 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 
 from ..core.client import KISClient
+from ..core.constants import WS_REAL_URL
 from ..stock.api import StockAPI
 
 # 로깅 레벨을 INFO로 설정
@@ -49,7 +50,7 @@ class KisWebSocket:
         self.client = client
         self.account_info = account_info
         self.stock_api = StockAPI(client=client, account_info=account_info)
-        self.url = "ws://ops.koreainvestment.com:21000"  # 고정 URL
+        self.url = WS_REAL_URL  # 고정 URL (constants.WS_REAL_URL)
         self.stock_codes = stock_codes or []
 
         # 기능 활성화 플래그

--- a/kis_agent/websocket/connection.py
+++ b/kis_agent/websocket/connection.py
@@ -11,6 +11,8 @@ from typing import Any, Dict
 
 import websockets
 
+from ..core.constants import WS_REAL_URL
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,7 +31,7 @@ class ConnectionManager:
 
     def __init__(
         self,
-        url: str = "ws://ops.koreainvestment.com:21000",
+        url: str = WS_REAL_URL,
         ping_interval: int = 30,
         ping_timeout: int = 30,
         auto_reconnect: bool = True,

--- a/kis_agent/websocket/factory.py
+++ b/kis_agent/websocket/factory.py
@@ -32,6 +32,7 @@ import warnings
 from enum import Enum
 from typing import List, Union
 
+from ..core.constants import WS_REAL_URL
 from .connection import ConnectionManager
 from .data_processor import DataProcessor
 from .event_manager import EventManager
@@ -117,7 +118,7 @@ class WebSocketClientFactory:
         최소한의 기능만 포함된 가벼운 클라이언트입니다.
         """
         connection = ConnectionManager(
-            url=kwargs.get("url", "ws://ops.koreainvestment.com:21000"),
+            url=kwargs.get("url", WS_REAL_URL),
             auto_reconnect=False,
         )
 
@@ -145,7 +146,7 @@ class WebSocketClientFactory:
         자동 재연결, 로깅, 메트릭 수집이 활성화된 클라이언트입니다.
         """
         connection = ConnectionManager(
-            url=kwargs.get("url", "ws://ops.koreainvestment.com:21000"),
+            url=kwargs.get("url", WS_REAL_URL),
             auto_reconnect=True,
             ping_interval=20,
             ping_timeout=30,
@@ -188,7 +189,7 @@ class WebSocketClientFactory:
         시장 전반을 모니터링하기 위한 클라이언트입니다.
         """
         connection = ConnectionManager(
-            url=kwargs.get("url", "ws://ops.koreainvestment.com:21000"),
+            url=kwargs.get("url", WS_REAL_URL),
             auto_reconnect=True,
             ping_interval=30,
             ping_timeout=30,
@@ -229,7 +230,7 @@ class WebSocketClientFactory:
         백테스트용으로 데이터만 수집하는 클라이언트입니다.
         """
         connection = ConnectionManager(
-            url=kwargs.get("url", "ws://ops.koreainvestment.com:21000"),
+            url=kwargs.get("url", WS_REAL_URL),
             auto_reconnect=False,  # 백테스트는 재연결 불필요
         )
 
@@ -292,7 +293,7 @@ class WebSocketClientBuilder:
             stacklevel=2,
         )
         self.approval_key = approval_key
-        self.url = "ws://ops.koreainvestment.com:21000"
+        self.url = WS_REAL_URL
         self.auto_reconnect = True
         self.ping_interval = 30
         self.ping_timeout = 30

--- a/kis_agent/websocket/ws_agent.py
+++ b/kis_agent/websocket/ws_agent.py
@@ -14,6 +14,7 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 from websockets.exceptions import ConnectionClosed
 
+from ..core.constants import WS_REAL_URL
 from .ws_helpers import RealtimeDataParser, RealtimeDataStore, WSAgentWithStore
 from .ws_types import Subscription, SubscriptionType
 
@@ -82,7 +83,7 @@ class WSAgent:
     def __init__(
         self,
         approval_key: str,
-        url: str = "ws://ops.koreainvestment.com:21000",
+        url: str = WS_REAL_URL,
         ping_interval: int = 30,
         ping_timeout: int = 30,
         auto_reconnect: bool = True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kis-agent"
-version = "1.6.1"
+version = "1.7.0"
 description = "한국투자증권 OpenAPI Python Wrapper - Korea Investment & Securities Trading API Client"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

환경변수 이름과 URL/엔드포인트 상수 일관성을 정리하고, 보안 표면을 축소합니다.

- 환경변수 `KIS_*` prefix로 통일, legacy 별칭 즉시 제거
- `kis_agent/core/constants.py` 신설 — URL/Enum/User-Agent 단일 진실의 출처
- `kis_agent/core/endpoints.py` 신설 — `API_ENDPOINTS` dict 분리
- `KISConfig.from_env()` 추가, `client.py`의 `os.getenv` 분산 호출 단일화
- WebSocket URL 8곳 하드코딩을 `WS_REAL_URL` 참조로 통일
- `.env.example` 전면 재작성 (이전엔 무관한 LLM API 키 템플릿이었음)
- `auth.py`의 `load_dotenv`를 `override=False`로, 패키지 부모 디렉토리 검색 제거

## ⚠️ BREAKING CHANGES

다음 환경변수 별칭이 더 이상 인식되지 않습니다 (`KIS_*` 만 인식):

| 이전 이름 | 새 이름 |
| --- | --- |
| `MY_APP` | `KIS_APP_KEY` |
| `MY_SEC` / `KIS_SECRET` | `KIS_APP_SECRET` |
| `MY_ACCT_STOCK` | `KIS_ACCOUNT_NO` |
| `MY_PROD` | `KIS_ACCOUNT_CODE` |
| `PROD_URL` | `KIS_BASE_URL` |
| `VPS_URL` | `KIS_VPS_URL` |
| `MY_AGENT` | `KIS_USER_AGENT` |

`KISConfig` 매개변수 시그니처와 공개 API(`Agent`, `KisWebSocket`)는 변경 없음.

## Changes (17 files)

**신규**
- `kis_agent/core/constants.py`
- `kis_agent/core/endpoints.py`

**수정**
- `kis_agent/core/{config,auth,client,agent}.py`
- `kis_agent/cli_bridge.py`, `kis_agent/cli/main.py`
- `kis_agent/websocket/{ws_agent,client,factory,connection}.py`
- `kis_agent/__init__.py` (버전 → 1.7.0)
- `.env.example`, `README.md`, `CHANGELOG.md`, `pyproject.toml`

## Test plan

- [x] `ruff check` — all checks passed
- [x] 공개 API import (`Agent`, `KisWebSocket`, `ResponseStatus`, `KISConfig.from_env`) 정상
- [x] `KISConfig.from_env()` round-trip 검증 (실전/모의 모두)
- [x] Legacy 환경변수 무시 확인 (`MY_APP`만 설정 시 `_cfg["my_app"]`은 빈 문자열)
- [x] 단위 테스트 445 passed (1 pre-existing failure: `test_make_request_success` — 이번 리팩터와 무관, 사전 검증으로 base에서도 실패함을 확인)
- [ ] 실제 KIS API 호출 검증 (수동, `.env` 갱신 후)
- [ ] 통합 테스트 (`tests/kis_integration_test.py`) — `.env`에 `KIS_*` 변수 채운 뒤