### PR TITLE
docs,examples: standardize KIS_ACCOUNT_NUMBER → KIS_ACCOUNT_NO + KIS_ACCOUNT_CODE

### DIFF
--- a/docs/api/websocket-api.md
+++ b/docs/api/websocket-api.md
@@ -351,12 +351,14 @@ from kis_agent.core.client import KISClient
 from kis_agent.websocket import WSAgent, SubscriptionType
 
 async def main():
-    # 클라이언트 초기화
-    client = KISClient(
+    # 클라이언트 초기화 (KISConfig를 통한 설정 권장)
+    from kis_agent.core.config import KISConfig
+    client = KISClient(config=KISConfig(
         app_key="your_app_key",
         app_secret="your_app_secret",
-        account_number="your_account"
-    )
+        account_no="12345678",
+        account_code="01",
+    ))
     
     # WSAgent 생성
     approval_key = client.get_ws_approval_key()
@@ -426,7 +428,8 @@ asyncio.run(main())
 ```bash
 KIS_APP_KEY=your_app_key
 KIS_APP_SECRET=your_app_secret
-KIS_ACCOUNT_NUMBER=your_account
+KIS_ACCOUNT_NO=12345678          # 종합계좌번호 앞 8자리
+KIS_ACCOUNT_CODE=01              # 계좌 상품코드
 ```
 
 ### 로깅 설정

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -43,7 +43,8 @@ pip install -e .
 # .env 파일
 KIS_APP_KEY=your_app_key_here
 KIS_APP_SECRET=your_app_secret_here
-KIS_ACCOUNT_NUMBER=12345678-01
+KIS_ACCOUNT_NO=12345678   # 종합계좌번호 앞 8자리
+KIS_ACCOUNT_CODE=01       # 계좌 상품코드 (주식: "01", 선물옵션: "03")
 ```
 
 ### 2. 설정 파일 확인
@@ -56,49 +57,53 @@ from dotenv import load_dotenv
 load_dotenv()
 
 print("App Key:", os.getenv('KIS_APP_KEY')[:10] + "...")
-print("Account:", os.getenv('KIS_ACCOUNT_NUMBER'))
+print("Account:", os.getenv('KIS_ACCOUNT_NO'), os.getenv('KIS_ACCOUNT_CODE'))
 ```
 
 ## 🔑 기본 인증
 
-### KISClient 초기화
-```python
-from kis_agent.core.client import KISClient
+### Agent 초기화 (권장)
 
-# 클라이언트 생성
-client = KISClient(
-    app_key=os.getenv('KIS_APP_KEY'),
-    app_secret=os.getenv('KIS_APP_SECRET'),
-    account_number=os.getenv('KIS_ACCOUNT_NUMBER'),
-    is_real=True  # 실전투자: True, 모의투자: False
+`Agent`는 KISClient·인증·각 도메인 API(StockAPI 등)를 하나로 묶은 파사드입니다.
+`.env`에서 `KIS_*` 환경변수를 자동으로 읽고 싶으면 `KISConfig.from_env()`를 사용하세요.
+
+```python
+from kis_agent import Agent
+from kis_agent.core.config import KISConfig
+
+# (a) 환경변수에서 자동 로드
+config = KISConfig.from_env()
+agent = Agent(
+    app_key=config.APP_KEY,
+    app_secret=config.APP_SECRET,
+    account_no=config.ACCOUNT_NO,
+    account_code=config.ACCOUNT_CODE,
+    base_url=config.BASE_URL,  # 비워두면 실전투자 URL이 기본
 )
 
-# 연결 테스트
-print("인증 토큰:", client.get_access_token()[:20] + "...")
+# (b) 또는 명시적 매개변수
+agent = Agent(
+    app_key=os.getenv("KIS_APP_KEY"),
+    app_secret=os.getenv("KIS_APP_SECRET"),
+    account_no=os.getenv("KIS_ACCOUNT_NO"),
+    account_code=os.getenv("KIS_ACCOUNT_CODE", "01"),
+)
 ```
 
 ##  REST API 사용
 
 ### 주식 정보 조회
 ```python
-from kis_agent.stock.api import StockAPI
+# Agent를 통해 주식 도메인 API 호출
+price = agent.get_stock_price("005930")  # 삼성전자
+print(f"삼성전자 현재가: {price['output']['stck_prpr']}원")
 
-# 계좌 정보 설정
-account_info = {
-    'CANO': os.getenv('KIS_ACCOUNT_NUMBER').split('-')[0],
-    'ACNT_PRDT_CD': os.getenv('KIS_ACCOUNT_NUMBER').split('-')[1]
-}
-
-# 주식 API 초기화
-stock_api = StockAPI(client=client, account_info=account_info)
-
-# 삼성전자 현재가 조회
-price_data = stock_api.get_stock_price("005930")
-print(f"삼성전자 현재가: {price_data['output']['stck_prpr']}원")
-
-# 일일 가격 데이터 조회
-daily_data = stock_api.get_daily_price("005930")
-print(f"일일 데이터 건수: {len(daily_data)}개")
+# 기간별 일봉 데이터
+daily = agent.inquire_daily_itemchartprice(
+    "005930",
+    start_date="20250101",
+    end_date="20251231",
+)
 ```
 
 ### 계좌 정보 조회

--- a/examples/export_trading_history.py
+++ b/examples/export_trading_history.py
@@ -53,17 +53,21 @@ def main():
     # 1. KIS 클라이언트 초기화
     logger.info("KIS 클라이언트 초기화...")
 
-    KISClient(
+    from kis_agent.core.config import KISConfig
+    from kis_agent.core.constants import MOCK_BASE_URL
+
+    KISClient(config=KISConfig(
         app_key=os.getenv("KIS_APP_KEY"),
         app_secret=os.getenv("KIS_APP_SECRET"),
-        account_number=os.getenv("KIS_ACCOUNT_NUMBER"),
-        is_real=False,  # 모의투자로 테스트
-    )
+        account_no=os.getenv("KIS_ACCOUNT_NO"),
+        account_code=os.getenv("KIS_ACCOUNT_CODE", "01"),
+        base_url=MOCK_BASE_URL,  # 모의투자로 테스트
+    ))
 
     # 계좌 정보 설정
     account_info = {
-        "CANO": os.getenv("KIS_ACCOUNT_NUMBER").split("-")[0],
-        "ACNT_PRDT_CD": os.getenv("KIS_ACCOUNT_NUMBER").split("-")[1],
+        "CANO": os.getenv("KIS_ACCOUNT_NO"),
+        "ACNT_PRDT_CD": os.getenv("KIS_ACCOUNT_CODE", "01"),
     }
 
     # 2. 날짜 설정 (최근 30일)

--- a/examples/websocket_multi_subscribe.py
+++ b/examples/websocket_multi_subscribe.py
@@ -120,25 +120,28 @@ async def main():
 
     load_dotenv()
 
+    from kis_agent.core.config import KISConfig
+
     app_key = os.getenv("KIS_APP_KEY")
     app_secret = os.getenv("KIS_APP_SECRET")
-    account_number = os.getenv("KIS_ACCOUNT_NUMBER")
+    account_no = os.getenv("KIS_ACCOUNT_NO")
+    account_code = os.getenv("KIS_ACCOUNT_CODE", "01")
 
-    if not all([app_key, app_secret, account_number]):
+    if not all([app_key, app_secret, account_no]):
         print(
-            "환경변수를 설정해주세요: KIS_APP_KEY, KIS_APP_SECRET, KIS_ACCOUNT_NUMBER"
+            "환경변수를 설정해주세요: KIS_APP_KEY, KIS_APP_SECRET, KIS_ACCOUNT_NO"
         )
         return
 
-    # 클라이언트 초기화
-    client = KISClient(
+    # 클라이언트 초기화 (실전 URL이 기본)
+    client = KISClient(config=KISConfig(
         app_key=app_key,
         app_secret=app_secret,
-        account_number=account_number,
-        is_real=True,  # 실전투자
-    )
+        account_no=account_no,
+        account_code=account_code,
+    ))
 
-    account_info = {"CANO": account_number[:8], "ACNT_PRDT_CD": account_number[8:]}
+    account_info = {"CANO": account_no, "ACNT_PRDT_CD": account_code}
 
     # 감시할 종목 설정
     stock_codes = [


### PR DESCRIPTION
## Summary

v1.7.0 환경변수 표준화(PR #33)의 후속 정리. docs/examples에 남아있던 비표준 환경변수 `KIS_ACCOUNT_NUMBER` (합본 \"12345678-01\" 형식)를 표준 `KIS_ACCOUNT_NO` + `KIS_ACCOUNT_CODE` 분리 형식으로 통일.

## Changes

- `docs/guides/getting-started.md`: env 예제 + Agent 파사드 사용법으로 재작성
- `docs/api/websocket-api.md`: KISClient `account_number=` → `KISConfig(account_no=, account_code=)`
- `examples/websocket_multi_subscribe.py`: outdated KISClient 시그니처 수정 + KIS_ACCOUNT_NO/CODE 분리
- `examples/export_trading_history.py`: 동일하게 표준화, MOCK_BASE_URL 상수 사용

## 같이 정리한 outdated API 호출

코드와 일치하지 않던 docs/examples를 실제 시그니처로 맞춤:
- ~~`KISClient(account_number=..., is_real=True)`~~ → `KISClient(config=KISConfig(account_no=..., account_code=..., base_url=...))`
- ~~`account_number[:8]` / `account_number[8:]`~~ — 슬라이싱 hack 제거
- getting-started의 ~~`get_access_token`, `get_daily_price`~~ 같은 실존하지 않는 메서드를 실제 Agent 파사드(`agent.get_stock_price`, `agent.inquire_daily_itemchartprice`)로 교체

## Test plan

- [x] `python -m py_compile` 두 examples 통과
- [x] `KIS_ACCOUNT_NUMBER` / `account_number=` 잔존 검색 0건
- [ ] (선택) examples 실제 실행 — 사용자 .env 갱신 필요