### PR TITLE
feat(constants): add get_ws_url helper for real/mock WebSocket selection

### DIFF
--- a/kis_agent/core/constants.py
+++ b/kis_agent/core/constants.py
@@ -11,10 +11,33 @@ from enum import Enum
 REAL_BASE_URL = "https://openapi.koreainvestment.com:9443"
 MOCK_BASE_URL = "https://openapivts.koreainvestment.com:29443"
 
+# WebSocket 엔드포인트
+# (KIS 공식 샘플 open-trading-api/legacy/websocket/python/* 에서 확인된 값)
 WS_REAL_URL = "ws://ops.koreainvestment.com:21000"
 WS_MOCK_URL = "ws://ops.koreainvestment.com:31000"
 
 KIS_USER_AGENT_DEFAULT = "KIS_AGENT"
+
+
+def get_ws_url(is_real: bool = True) -> str:
+    """실전/모의 WebSocket URL을 선택한다.
+
+    KIS는 실전과 모의 WS 엔드포인트를 분리 운영한다:
+    - 실전: `ws://ops.koreainvestment.com:21000` (`WS_REAL_URL`)
+    - 모의: `ws://ops.koreainvestment.com:31000` (`WS_MOCK_URL`)
+
+    Args:
+        is_real: True면 실전 URL, False면 모의 URL.
+
+    Returns:
+        선택된 WebSocket URL.
+
+    Example:
+        >>> from kis_agent.core.constants import get_ws_url
+        >>> from kis_agent.websocket import WSAgent
+        >>> ws = WSAgent(approval_key, url=get_ws_url(is_real=False))
+    """
+    return WS_REAL_URL if is_real else WS_MOCK_URL
 
 
 class AccountProductCode(str, Enum):
@@ -35,4 +58,5 @@ __all__ = [
     "WS_MOCK_URL",
     "KIS_USER_AGENT_DEFAULT",
     "AccountProductCode",
+    "get_ws_url",
 ]

--- a/kis_agent/websocket/__init__.py
+++ b/kis_agent/websocket/__init__.py
@@ -17,6 +17,10 @@ WebSocket 모듈
     ws.subscribe_stocks(["005930", "000660"])
     await ws.connect()
 
+    # 모의투자 엔드포인트 사용
+    from kis_agent.core.constants import get_ws_url
+    ws = WSAgent(approval_key, url=get_ws_url(is_real=False))
+
 .. deprecated:: 1.3.0
     KisWebSocket, EnhancedWebSocketClient, RefactoredWebSocketClient,
     WebSocketClientFactory, WebSocketClientBuilder는 deprecated되었습니다.


### PR DESCRIPTION
## Summary

v1.7.0(#33)에서 도입했지만 미사용으로 dead code 상태였던 `WS_MOCK_URL`을 활성화하는 헬퍼 추가.

## Verified

KIS 공식 샘플 코드 `open-trading-api/legacy/websocket/python/{ws_domestic_overseas_all,ws_domestic+overseas_stock,ops_ws_sample,ws_commodity_future,ws_domestic_stock,ws_domestic_future,multi_processing_sample_ws}.py`에서 모두 모의투자 WS 엔드포인트로 \`ws://ops.koreainvestment.com:31000\`을 주석으로 명시 — 본 PR의 \`WS_MOCK_URL\`이 KIS 공식과 일치함을 확인.

## Changes

- `kis_agent/core/constants.py`: \`get_ws_url(is_real: bool = True) -> str\` 헬퍼 추가
- `kis_agent/websocket/__init__.py`: 도크스트링에 모의 엔드포인트 사용 예제 추가

## Compatibility

- 기존 \`WSAgent\`, \`KisWebSocket\`, \`ConnectionManager\`의 \`url\` 매개변수 기본값(WS_REAL_URL)은 변경 없음
- 모의 사용자는 \`WSAgent(approval_key, url=get_ws_url(False))\`로 명시적 선택

## Test plan

- [x] \`get_ws_url(True) == WS_REAL_URL\`, \`get_ws_url(False) == WS_MOCK_URL\`
- [x] \`ruff check\` 통과
- [x] 공개 API import 정상