### PR TITLE
fix(test): mock httpx.request instead of requests.request in make_request tests

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -183,7 +183,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_success(self, mock_request, mock_get_tr_env, mock_auth):
         """API 요청 성공"""
         mock_auth.return_value = {
@@ -221,7 +221,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_json_decode_error(
         self, mock_request, mock_get_tr_env, mock_auth
     ):
@@ -259,7 +259,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_no_rt_cd(self, mock_request, mock_get_tr_env, mock_auth):
         """rt_cd 없는 응답 처리"""
         mock_auth.return_value = {
@@ -289,7 +289,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_api_error(self, mock_request, mock_get_tr_env, mock_auth):
         """API 오류 응답 처리"""
         mock_auth.return_value = {
@@ -323,7 +323,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_http_error_with_retry(
         self, mock_request, mock_get_tr_env, mock_auth
     ):
@@ -363,7 +363,7 @@ class TestKISClientUnit(unittest.TestCase):
 
     @patch("kis_agent.core.client.auth")
     @patch("kis_agent.core.client.getTREnv")
-    @patch("requests.request")
+    @patch("httpx.request")
     def test_make_request_exception_handling(
         self, mock_request, mock_get_tr_env, mock_auth
     ):

--- a/tests/unit/test_client_comprehensive.py
+++ b/tests/unit/test_client_comprehensive.py
@@ -354,7 +354,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {
@@ -392,7 +392,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     # json.JSONDecodeError를 발생시켜야 함
@@ -426,7 +426,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {"data": "no_rt_cd"}
@@ -456,7 +456,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {
@@ -508,7 +508,7 @@ class TestMakeRequest:
                         }
                     return mock_response
 
-                with patch("requests.request", side_effect=side_effect):
+                with patch("httpx.request", side_effect=side_effect):
                     client = client_module.KISClient(
                         enable_rate_limiter=False, verbose=False
                     )
@@ -552,7 +552,7 @@ class TestMakeRequest:
                         }
                     return mock_response
 
-                with patch("requests.request", side_effect=side_effect), patch(
+                with patch("httpx.request", side_effect=side_effect), patch(
                     "time.sleep"
                 ):  # 대기 시간 건너뛰기
                     client = client_module.KISClient(
@@ -578,7 +578,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 500
                     mock_response.json.return_value = {
@@ -612,7 +612,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_request.side_effect = requests.exceptions.ConnectionError(
                         "Connection failed"
                     )
@@ -640,7 +640,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {"rt_cd": "0"}
@@ -672,7 +672,7 @@ class TestMakeRequest:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {"rt_cd": "0", "output": {}}
@@ -809,7 +809,7 @@ class TestGetKospi200Index:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {
@@ -982,7 +982,7 @@ class TestRateLimiterIntegration:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {"rt_cd": "0"}
@@ -1016,7 +1016,7 @@ class TestRateLimiterIntegration:
                 mock_tr_env.my_token = "Bearer token"
                 mock_get_tr_env.return_value = mock_tr_env
 
-                with patch("requests.request") as mock_request:
+                with patch("httpx.request") as mock_request:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {


### PR DESCRIPTION
## Summary

v1.6.1에서 \`KISClient.make_request\`가 \`requests\` → \`httpx\`로 교체되었으나 (commit 52cb530), 테스트의 mock 타겟이 그대로 \`requests.request\`에 머물러 있었던 문제 수정.

## Root cause

\`client.py:297\` \`httpx.request(...)\`를 호출하지만 테스트는 \`@patch(\"requests.request\")\`로 mocking 중이어서 실제 httpx 호출이 일어남. 그 결과 인증 실패 → \`JSON_DECODE_ERROR\` 반환으로 \`test_make_request_success\` 등이 항상 실패하던 상태.

## Changes

- \`tests/unit/test_client.py\`: 6개 \`@patch(\"requests.request\")\` → \`@patch(\"httpx.request\")\`
- \`tests/unit/test_client_comprehensive.py\`: 7개 \`patch(\"requests.request\")\` → \`patch(\"httpx.request\")\`
- \`@patch(\"requests.post\")\`는 토큰 갱신용으로 \`client.py:480\`가 여전히 \`requests.post\`를 쓰므로 그대로 유지

## Test plan

- [x] \`pytest tests/unit/test_client.py\` — 22 passed
- [x] \`pytest tests/unit/test_client_comprehensive.py\` — 36 passed
- [x] 합계 58/58 passed (이전엔 \`test_make_request_success\` 등이 실패)