### PR TITLE
fix(bridge): harden PythonBridge error handling and bound buffers (STO-1411)

### DIFF
--- a/src/__tests__/python-bridge.test.ts
+++ b/src/__tests__/python-bridge.test.ts
@@ -251,7 +251,8 @@ describe('PythonBridge', () => {
       const responsePromise = bridge.call({ method: 'test_api.method', params: { code: '005930' } });
 
       expect(child.stdin.write).toHaveBeenCalledWith(
-        '{"method":"test_api.method","params":{"code":"005930"}}\n'
+        '{"method":"test_api.method","params":{"code":"005930"}}\n',
+        expect.any(Function)
       );
 
       child.stdout.emit('data', '{"success":true,"data":{"price":70000}}');
@@ -278,8 +279,16 @@ describe('PythonBridge', () => {
       await expect(second).resolves.toEqual({ success: true, data: { step: 2 } });
 
       expect(spawn).toHaveBeenCalledTimes(1);
-      expect(child.stdin.write).toHaveBeenNthCalledWith(1, '{"method":"test_api.first"}\n');
-      expect(child.stdin.write).toHaveBeenNthCalledWith(2, '{"method":"test_api.second"}\n');
+      expect(child.stdin.write).toHaveBeenNthCalledWith(
+        1,
+        '{"method":"test_api.first"}\n',
+        expect.any(Function)
+      );
+      expect(child.stdin.write).toHaveBeenNthCalledWith(
+        2,
+        '{"method":"test_api.second"}\n',
+        expect.any(Function)
+      );
     });
 
     it('should reject concurrent calls when no request id is available', async () => {
@@ -331,6 +340,52 @@ describe('PythonBridge', () => {
         _notice: 'market closed',
       });
     });
+
+    it('should reject immediately when stdin.write reports an error', async () => {
+      const child = createMockChild();
+      child.stdin.write.mockImplementation((_data: string, cb?: (err?: Error | null) => void) => {
+        cb?.(new Error('write EPIPE'));
+        return false;
+      });
+      (spawn as jest.Mock).mockReturnValue(child);
+
+      const bridge = new PythonBridge('/tmp/dummy_bridge.py');
+
+      await expect(bridge.call({ method: 'test_api.method' })).rejects.toMatchObject({
+        code: 'StdinWriteError',
+      });
+    });
+
+    it('should reject when the stdin stream emits an error event', async () => {
+      const child = createMockChild();
+      (spawn as jest.Mock).mockReturnValue(child);
+
+      const bridge = new PythonBridge('/tmp/dummy_bridge.py');
+      const responsePromise = bridge.call({ method: 'test_api.method' });
+
+      child.stdin.emit('error', new Error('EPIPE'));
+
+      await expect(responsePromise).rejects.toMatchObject({
+        code: 'StdinError',
+      });
+    });
+
+    it('should reject when stdout grows past the buffer limit without a newline', async () => {
+      const child = createMockChild();
+      (spawn as jest.Mock).mockReturnValue(child);
+
+      const bridge = new PythonBridge('/tmp/dummy_bridge.py');
+      const responsePromise = bridge.call({ method: 'test_api.method' });
+
+      // No newline → the line is never dispatched; buffer must be bounded.
+      child.stdout.emit('data', 'x'.repeat(1024 * 1024 + 1));
+
+      await expect(responsePromise).rejects.toMatchObject({
+        code: 'ResponseOverflow',
+      });
+      expect(child.kill).toHaveBeenCalled();
+      expect(bridge['stdoutBuffer']).toBe('');
+    });
   });
 
   describe('Synchronous Call', () => {
@@ -354,6 +409,24 @@ describe('PythonBridge', () => {
         success: true,
         data: { ok: true },
       });
+    });
+
+    it('should throw PythonBridgeError when the bridge returns a failure response', () => {
+      (execFileSync as jest.Mock).mockReturnValue(
+        '{"success":false,"error":"Invalid code","code":"ValueError"}\n'
+      );
+
+      const bridge = new PythonBridge('/tmp/dummy_bridge.py');
+
+      expect(() => bridge.callSync({ method: 'test_api.method' })).toThrow(PythonBridgeError);
+      try {
+        bridge.callSync({ method: 'test_api.method' });
+      } catch (error) {
+        expect(error).toBeInstanceOf(PythonBridgeError);
+        // Must preserve the structured code, not re-wrap it as ProcessError.
+        expect((error as PythonBridgeError).code).toBe('ValueError');
+        expect((error as PythonBridgeError).message).toBe('Invalid code');
+      }
     });
   });
 });

--- a/src/python-bridge.ts
+++ b/src/python-bridge.ts
@@ -47,6 +47,11 @@ export class PythonBridgeError extends Error {
 }
 
 export class PythonBridge extends EventEmitter {
+  // Bounded buffers guard against unbounded memory growth from a misbehaving
+  // bridge process (stderr floods / oversized stdout without a newline).
+  private static readonly MAX_STDERR_BUFFER = 64 * 1024;
+  private static readonly MAX_STDOUT_BUFFER = 1024 * 1024;
+
   private scriptPath: string;
   private timeout: number = 30000; // 기본 30000ms
   private pythonCommand: string = 'python3';
@@ -175,9 +180,22 @@ export class PythonBridge extends EventEmitter {
 
     child.stderr.on('data', (data: string) => {
       if (this.pendingRequest) {
-        this.pendingRequest.stderr += data;
+        const combined = this.pendingRequest.stderr + data;
+        // Keep the most recent bytes so the tail (usually the exception line) survives.
+        this.pendingRequest.stderr =
+          combined.length > PythonBridge.MAX_STDERR_BUFFER
+            ? combined.slice(combined.length - PythonBridge.MAX_STDERR_BUFFER)
+            : combined;
       }
       this.emit('stderr', data);
+    });
+
+    // Without an 'error' listener an EPIPE (writing to a dead process) would be
+    // thrown as an unhandled stream error and crash the Node process.
+    child.stdin.on('error', (error: Error) => {
+      this.failPendingRequest(
+        new PythonBridgeError('StdinError', `Python bridge stdin stream error: ${error.message}`)
+      );
     });
 
     child.on('close', (code, signal) => {
@@ -237,6 +255,41 @@ export class PythonBridge extends EventEmitter {
 
       this.handleResponseLine(line);
     }
+
+    // Guard against unbounded growth when no newline-delimited response ever
+    // arrives (broken JSON fragment or an oversized single line from the bridge).
+    if (this.stdoutBuffer.length > PythonBridge.MAX_STDOUT_BUFFER) {
+      this.stdoutBuffer = '';
+      this.failPendingRequest(
+        new PythonBridgeError(
+          'ResponseOverflow',
+          `Python bridge stdout exceeded ${PythonBridge.MAX_STDOUT_BUFFER} bytes without a complete response line`
+        )
+      );
+      if (this.child && !this.child.killed) {
+        this.child.kill('SIGTERM');
+      }
+    }
+  }
+
+  /**
+   * 진행 중인 요청을 정리하고 에러로 reject. pendingRequest가 없으면 no-op이므로
+   * 여러 실패 경로(stdin write/error, stdout overflow)에서 중복 호출해도 안전하다.
+   */
+  private failPendingRequest(error: PythonBridgeError): void {
+    const pending = this.pendingRequest;
+    if (!pending) {
+      return;
+    }
+
+    this.pendingRequest = null;
+    clearTimeout(pending.timeoutHandle);
+
+    if (error.pythonError === undefined && pending.stderr) {
+      error.pythonError = pending.stderr;
+    }
+
+    pending.reject(error);
   }
 
   private handleResponseLine(line: string): void {
@@ -331,9 +384,19 @@ export class PythonBridge extends EventEmitter {
         timeoutHandle,
       };
 
-      // 요청 JSON을 stdin으로 전송
+      // 요청 JSON을 stdin으로 전송 — write 실패(닫힌 stdin, EPIPE)를 즉시 reject해
+      // timeout까지 대기하지 않도록 한다.
       const requestJson = JSON.stringify(request);
-      child.stdin.write(requestJson + '\n');
+      child.stdin.write(requestJson + '\n', (writeError) => {
+        if (writeError) {
+          this.failPendingRequest(
+            new PythonBridgeError(
+              'StdinWriteError',
+              `Failed to write request to Python bridge stdin: ${writeError.message}`
+            )
+          );
+        }
+      });
     });
   }
 
@@ -355,8 +418,21 @@ export class PythonBridge extends EventEmitter {
       );
 
       const response: BridgeResponse = JSON.parse(output.trim());
+
+      // async call()과 동일하게, 실패 응답은 성공 경로로 반환하지 않고 throw한다.
+      if (!response.success && response.code) {
+        throw new PythonBridgeError(
+          response.code,
+          response.error || 'Unknown error from Python bridge'
+        );
+      }
+
       return response;
     } catch (error) {
+      // 위에서 던진 구조화된 에러는 ProcessError로 재포장하지 않고 그대로 전파.
+      if (error instanceof PythonBridgeError) {
+        throw error;
+      }
       if (error instanceof Error) {
         if (error.message.includes('ETIMEDOUT')) {
           throw new PythonBridgeError(


### PR DESCRIPTION
## Summary

Fixes the 4 codebase-audit findings in `src/python-bridge.ts` (STO-1411, `openswarm review --max`).

| Type | Location | Fix |
|---|---|---|
| bug | `python-bridge.ts:336` | `stdin.write()` failures and `stdin` `'error'` events (EPIPE / closed stdin) now reject the pending request immediately as `StdinWriteError`/`StdinError` instead of hanging until timeout or crashing Node with an unhandled stream error. |
| bug | `python-bridge.ts:357` | `callSync()` now throws `PythonBridgeError` for `{ success: false, code }` responses so its error semantics match async `call()`; the catch block no longer re-wraps `PythonBridgeError` as `ProcessError`. |
| perf | `python-bridge.ts:178` | per-request stderr buffer bounded to 64KB (tail kept). |
| perf | `python-bridge.ts:223` | stdout line buffer bounded to 1MB; on overflow reject with `ResponseOverflow`, reset buffer, kill process. |

Adds an idempotent `failPendingRequest()` helper shared by the new failure paths.

## Verification

Ran via an ephemeral ts-jest harness (repo has no bundled TS toolchain — CLI scaffolding was never built):

- **jest: 29/29 pass** — 25 existing + 4 new (stdin write error, stdin stream error, stdout overflow, callSync failure-response throw). Updated 2 existing assertions for the new `stdin.write` callback signature.
- **`tsc --noEmit` clean** (strict, `@types/node`).
- Node 22 type-stripping syntax check passes.

No live KIS API calls (mock/type level only) — no account/order side effects. E2E is out of scope (no CLI entrypoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)